### PR TITLE
Small change to silence deprecation warning

### DIFF
--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -11,7 +11,7 @@ module Lumberjack
   autoload :Severity, File.expand_path("../lumberjack/severity.rb", __FILE__)
   autoload :Template, File.expand_path("../lumberjack/template.rb", __FILE__)
   
-  LINE_SEPARATOR = (Config::CONFIG['host_os'].match(/mswin/i) ? "\r\n" : "\n")
+  LINE_SEPARATOR = (RbConfig::CONFIG['host_os'].match(/mswin/i) ? "\r\n" : "\n")
 
   class << self
     # Define a unit of work within a block. Within the block supplied to this


### PR DESCRIPTION
Fixes a deprecation warning that pops up with Ruby 1.9.3p0. Change works with 1.9.2p180 and 1.8.7p352.
