### PR TITLE
Enable manual rolling

### DIFF
--- a/lib/lumberjack/device/date_rolling_log_file.rb
+++ b/lib/lumberjack/device/date_rolling_log_file.rb
@@ -12,6 +12,7 @@ module Lumberjack
       # with the <tt>:roll</tt> option which may contain a value of <tt>:daily</tt>, <tt>:weekly</tt>,
       # or <tt>:monthly</tt>.
       def initialize(path, options = {})
+        @manual = options[:manual]
         @file_date = Date.today
         if options[:roll] && options[:roll].to_s.match(/(daily)|(weekly)|(monthly)/i)
           @roll_period = $~[0].downcase.to_sym
@@ -34,17 +35,21 @@ module Lumberjack
       end
 
       def roll_file?
-        date = Date.today
-        if date.year > @file_date.year
-          true
-        elsif @roll_period == :daily && date.yday > @file_date.yday
-          true
-        elsif @roll_period == :weekly && date.cweek > @file_date.cweek
-          true
-        elsif @roll_period == :monthly && date.month > @file_date.month
+        if @manual
           true
         else
-          false
+          date = Date.today
+          if date.year > @file_date.year
+            true
+          elsif @roll_period == :daily && date.yday > @file_date.yday
+            true
+          elsif @roll_period == :weekly && date.cweek > @file_date.cweek
+            true
+          elsif @roll_period == :monthly && date.month > @file_date.month
+            true
+          else
+            false
+          end
         end
       end
       

--- a/lib/lumberjack/device/size_rolling_log_file.rb
+++ b/lib/lumberjack/device/size_rolling_log_file.rb
@@ -10,6 +10,7 @@ module Lumberjack
       # Create an new log device to the specified file. The maximum size of the log file is specified with
       # the <tt>:max_size</tt> option. The unit can also be specified: "32K", "100M", "2G" are all valid.
       def initialize(path, options = {})
+        @manual = options[:manual]
         @max_size = options[:max_size]
         if @max_size.is_a?(String)
           if @max_size.match(/^(\d+(\.\d+)?)([KMG])?$/i)
@@ -37,7 +38,7 @@ module Lumberjack
       end
 
       def roll_file?
-        stream.stat.size > @max_size
+        @manual || stream.stat.size > @max_size
       rescue SystemCallError => e
         false
       end


### PR DESCRIPTION
Make the `roll_file!` method public so that the user can roll a log file manually.