### PR TITLE
Make lumberjack compatible with stdlib logger

### DIFF
--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -24,22 +24,22 @@ module Lumberjack
   # using a Formatter associated with the logger.
   class Logger
     include Severity
-    
+
     # The Formatter object used to convert messages into strings.
     attr_reader :formatter
-    
+
     # The time that the device was last flushed.
     attr_reader :last_flushed_at
-    
+
     # The name of the program associated with log messages.
     attr_writer :progname
-    
+
     # The device being written to.
     attr_reader :device
-    
+
     # Set +silencer+ to false to disable silencing the log.
     attr_accessor :silencer
-    
+
     # Create a new logger to log to a Device.
     #
     # The +device+ argument can be in any one of several formats.
@@ -60,27 +60,27 @@ module Lumberjack
     # All other options are passed to the device constuctor.
     def initialize(device = STDOUT, options = {})
       @thread_settings = {}
-      
+
       options = options.dup
       self.level = options.delete(:level) || INFO
       self.progname = options.delete(:progname)
       max_flush_seconds = options.delete(:flush_seconds).to_f
-      
+
       @device = open_device(device, options)
       @formatter = Formatter.new
       @lock = Mutex.new
       @last_flushed_at = Time.now
       @silencer = true
-      
+
       create_flusher_thread(max_flush_seconds) if max_flush_seconds > 0
     end
-    
+
     # Get the level of severity of entries that are logged. Entries with a lower
     # severity level will be ignored.
     def level
       thread_local_value(:lumberjack_logger_level) || @level
     end
-    
+
     # Add a message to the log with a given severity. The message can be either
     # passed in the +message+ argument or supplied with a block. This method
     # is not normally called. Instead call one of the helper functions
@@ -97,94 +97,105 @@ module Lumberjack
     #   logger.add(Lumberjack::Severity::DEBUG){"Start processing with options #{options.inspect}"}
     def add(severity, message = nil, progname = nil)
       severity = Severity.label_to_level(severity) if severity.is_a?(String) || severity.is_a?(Symbol)
-      if severity && severity >= level
-        time = Time.now
-        message = yield if message.nil? && block_given?
-        message = @formatter.format(message)
-        entry = LogEntry.new(time, severity, message, progname || self.progname, $$, Lumberjack.unit_of_work_id)
-        begin
-          device.write(entry)
-        rescue => e
-          $stderr.puts("#{e.class.name}: #{e.message}#{' at ' + e.backtrace.first if e.backtrace}")
-          $stderr.puts(entry.to_s)
+
+      return unless severity && severity >= level
+
+      time = Time.now
+      if message.nil?
+        if block_given?
+          message = yield
+        else
+          message = progname
+          progname = nil
         end
       end
+
+      message = @formatter.format(message)
+      progname ||= self.progname
+      entry = LogEntry.new(time, severity, message, progname, $$, Lumberjack.unit_of_work_id)
+      begin
+        device.write(entry)
+      rescue => e
+        $stderr.puts("#{e.class.name}: #{e.message}#{' at ' + e.backtrace.first if e.backtrace}")
+        $stderr.puts(entry.to_s)
+      end
+
       nil
     end
-    
+
     alias_method :log, :add
-    
+
     # Flush the logging device. Messages are not guaranteed to be written until this method is called.
     def flush
       device.flush
       @last_flushed_at = Time.now
       nil
     end
-    
+
     # Close the logging device.
     def close
       flush
       @device.close if @device.respond_to?(:close)
     end
-    
+
     # Log a +FATAL+ message. The message can be passed in either the +message+ argument or in a block.
     def fatal(message = nil, progname = nil, &block)
       add(FATAL, message, progname, &block)
     end
-    
+
     # Return +true+ if +FATAL+ messages are being logged.
     def fatal?
       level <= FATAL
     end
-    
+
     # Log an +ERROR+ message. The message can be passed in either the +message+ argument or in a block.
     def error(message = nil, progname = nil, &block)
       add(ERROR, message, progname, &block)
     end
-    
+
     # Return +true+ if +ERROR+ messages are being logged.
     def error?
       level <= ERROR
     end
-    
+
     # Log a +WARN+ message. The message can be passed in either the +message+ argument or in a block.
     def warn(message = nil, progname = nil, &block)
       add(WARN, message, progname, &block)
     end
-    
+
     # Return +true+ if +WARN+ messages are being logged.
     def warn?
       level <= WARN
     end
-    
+
     # Log an +INFO+ message. The message can be passed in either the +message+ argument or in a block.
     def info(message = nil, progname = nil, &block)
       add(INFO, message, progname, &block)
     end
-    
+
     # Return +true+ if +INFO+ messages are being logged.
     def info?
       level <= INFO
     end
-    
+
     # Log a +DEBUG+ message. The message can be passed in either the +message+ argument or in a block.
     def debug(message = nil, progname = nil, &block)
       add(DEBUG, message, progname, &block)
     end
-    
+
     # Return +true+ if +DEBUG+ messages are being logged.
     def debug?
       level <= DEBUG
     end
-    
+
     # Log a message when the severity is not known. Unknown messages will always appear in the log.
     # The message can be passed in either the +message+ argument or in a block.
     def unknown(message = nil, progname = nil, &block)
       add(UNKNOWN, message, progname, &block)
     end
-    
+
     alias_method :<<, :unknown
-    
+
     # Set the minimum level of severity of messages to log.
     def level=(severity)
       if severity.is_a?(Fixnum)
@@ -193,7 +204,7 @@ module Lumberjack
         @level = Severity.label_to_level(severity)
       end
     end
-    
+
     # Silence the logger by setting a new log level inside a block. By default, only +ERROR+ or +FATAL+
     # messages will be logged.
     #
@@ -210,7 +221,7 @@ module Lumberjack
         yield
       end
     end
-    
+
     # Set the program name that is associated with log messages. If a block
     # is given, the program name will be valid only within the block.
     def set_progname(value, &block)
@@ -220,14 +231,14 @@ module Lumberjack
         self.progname = value
       end
     end
-    
+
     # Get the program name associated with log messages.
     def progname
       thread_local_value(:lumberjack_logger_progname) || @progname
     end
-        
+
     private
-    
+
     # Set a local value for a thread tied to this object.
     def set_thread_local_value(name, value) #:nodoc:
       values = Thread.current[name]
@@ -242,13 +253,13 @@ module Lumberjack
         values[self] = value
       end
     end
-    
+
     # Get a local value for a thread tied to this object.
     def thread_local_value(name) #:nodoc:
       values = Thread.current[name]
       values[self] if values
     end
-    
+
     # Set a local value for a thread tied to this object within a block.
     def push_thread_local_value(name, value) #:nodoc:
       save_val = thread_local_value(name)
@@ -259,7 +270,7 @@ module Lumberjack
         set_thread_local_value(name, save_val)
       end
     end
-    
+
     # Open a logging device.
     def open_device(device, options) #:nodoc:
       if device.is_a?(Device)
@@ -279,7 +290,7 @@ module Lumberjack
         end
       end
     end
-    
+
     # Create a thread that will periodically call flush.
     def create_flusher_thread(flush_seconds) #:nodoc:
       if flush_seconds > 0

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -17,56 +17,56 @@ describe Lumberjack::Logger do
       logger = Lumberjack::Logger.new(output)
       logger.device.class.should == Lumberjack::Device::Writer
     end
-    
+
     it "should open a file path in a device" do
       logger = Lumberjack::Logger.new(File.join(tmp_dir, "log_file_1.log"))
       logger.device.class.should == Lumberjack::Device::LogFile
     end
-    
+
     it "should use the null device if the stream is :null" do
       logger = Lumberjack::Logger.new(:null)
       logger.device.class.should == Lumberjack::Device::Null
     end
-    
+
     it "should set the level with a numeric" do
       logger = Lumberjack::Logger.new(:null, :level => Lumberjack::Severity::WARN)
       logger.level.should == Lumberjack::Severity::WARN
     end
-    
+
     it "should set the level with a level" do
       logger = Lumberjack::Logger.new(:null, :level => :warn)
       logger.level.should == Lumberjack::Severity::WARN
     end
-    
+
     it "should default the level to INFO" do
       logger = Lumberjack::Logger.new(:null)
       logger.level.should == Lumberjack::Severity::INFO
     end
-    
+
     it "should set the progname"do
       logger = Lumberjack::Logger.new(:null, :progname => "app")
       logger.progname.should == "app"
     end
-    
+
     it "should create a thread to flush the device" do
       Thread.should_receive(:new)
       logger = Lumberjack::Logger.new(:null, :flush_seconds => 10)
     end
   end
-  
+
   context "attributes" do
     it "should have a level" do
       logger = Lumberjack::Logger.new
       logger.level = Lumberjack::Severity::DEBUG
       logger.level.should == Lumberjack::Severity::DEBUG
     end
-    
+
     it "should have a progname" do
       logger = Lumberjack::Logger.new
       logger.progname = "app"
       logger.progname.should == "app"
     end
-    
+
     it "should be able to silence the log in a block" do
       output = StringIO.new
       logger = Lumberjack::Logger.new(output, :buffer_size => 0, :level => Lumberjack::Severity::INFO, :template => ":message")
@@ -79,7 +79,7 @@ describe Lumberjack::Logger do
       logger.info("four")
       output.string.split.should == ["one", "three", "four"]
     end
-    
+
     it "should be able to customize the level of silence in a block" do
       output = StringIO.new
       logger = Lumberjack::Logger.new(output, :buffer_size => 0, :level => Lumberjack::Severity::INFO, :template => ":message")
@@ -93,7 +93,7 @@ describe Lumberjack::Logger do
       logger.info("four")
       output.string.split.should == ["one", "woof", "four"]
     end
-    
+
     it "should not be able to silence the logger if silencing is disabled" do
       output = StringIO.new
       logger = Lumberjack::Logger.new(output, :buffer_size => 0, :level => Lumberjack::Severity::INFO, :template => ":message")
@@ -107,7 +107,7 @@ describe Lumberjack::Logger do
       logger.info("four")
       output.string.split.should == ["one", "two", "three", "four"]
     end
-    
+
     it "should be able to set the progname in a block" do
       logger = Lumberjack::Logger.new
       logger.set_progname("app")
@@ -120,7 +120,7 @@ describe Lumberjack::Logger do
       block_executed.should == true
       logger.progname.should == "app"
     end
-    
+
     it "should only affect the current thread when silencing the logger" do
       output = StringIO.new
       logger = Lumberjack::Logger.new(output, :buffer_size => 0, :level => Lumberjack::Severity::INFO, :template => ":message")
@@ -144,7 +144,7 @@ describe Lumberjack::Logger do
         status = 2
       end
     end
-    
+
     it "should only affect the current thread when changing the progname in a block" do
       output = StringIO.new
       logger = Lumberjack::Logger.new(output, :progname => "thread1", :buffer_size => 0, :level => Lumberjack::Severity::INFO, :template => ":progname :message")
@@ -169,7 +169,7 @@ describe Lumberjack::Logger do
       end
     end
   end
-  
+
   context "flushing" do
     it "should autoflush the buffer if it hasn't been flushed in a specified number of seconds" do
       output = StringIO.new
@@ -184,7 +184,7 @@ describe Lumberjack::Logger do
       sleep(0.15)
       output.string.split(Lumberjack::LINE_SEPARATOR).should == ["message 1", "message 2", "message 3"]
     end
-    
+
     it "should write the log entries to the device on flush and update the last flushed time" do
       output = StringIO.new
       logger = Lumberjack::Logger.new(output, :level => Lumberjack::Severity::INFO, :template => ":message", :buffer_size => 32767)
@@ -195,7 +195,7 @@ describe Lumberjack::Logger do
       output.string.split(Lumberjack::LINE_SEPARATOR).should == ["message 1"]
       logger.last_flushed_at.should >= last_flushed_at
     end
-    
+
     it "should flush the buffer and close the devices" do
       output = StringIO.new
       logger = Lumberjack::Logger.new(output, :level => Lumberjack::Severity::INFO, :template => ":message", :buffer_size => 32767)
@@ -206,7 +206,7 @@ describe Lumberjack::Logger do
       output.should be_closed
     end
   end
-  
+
   context "logging" do
     let(:output){ StringIO.new }
     let(:device){ Lumberjack::Device::Writer.new(output, :buffer_size => 0) }
@@ -242,28 +242,37 @@ describe Lumberjack::Logger do
       end
       output.string.should == "[2011-01-30T12:31:56.123 INFO block(#{$$}) #] test#{n}"
     end
-    
+
+    it "should add entries with a progname but no message or block" do
+      time = Time.parse("2011-01-30T12:31:56.123")
+      Time.stub!(:now).and_return(time)
+      logger.set_progname("default") do
+        logger.add(Lumberjack::Severity::INFO, nil, "message")
+      end
+      output.string.should == "[2011-01-30T12:31:56.123 INFO default(#{$$}) #] message#{n}"
+    end
+
     it "should add entries with a block" do
       time = Time.parse("2011-01-30T12:31:56.123")
       Time.stub!(:now).and_return(time)
       logger.add(Lumberjack::Severity::INFO){"test"}
       output.string.should == "[2011-01-30T12:31:56.123 INFO test(#{$$}) #] test#{n}"
     end
-    
+
     it "should log entries (::Logger compatibility)" do
       time = Time.parse("2011-01-30T12:31:56.123")
       Time.stub!(:now).and_return(time)
       logger.log(Lumberjack::Severity::INFO, "test")
       output.string.should == "[2011-01-30T12:31:56.123 INFO test(#{$$}) #] test#{n}"
     end
-    
+
     it "should append messages with unknown severity to the log" do
       time = Time.parse("2011-01-30T12:31:56.123")
       Time.stub!(:now).and_return(time)
       logger << "test"
       output.string.should == "[2011-01-30T12:31:56.123 UNKNOWN test(#{$$}) #] test#{n}"
     end
-    
+
     it "should ouput entries to STDERR if they can't be written the the device" do
       stderr = $stderr
       $stderr = StringIO.new
@@ -278,17 +287,17 @@ describe Lumberjack::Logger do
         $stderr = stderr
       end
     end
-    
+
     context "log helper methods" do
       let(:device){ Lumberjack::Device::Writer.new(output, :buffer_size => 0, :template => ":message") }
-      
+
       it "should only add messages whose severity is greater or equal to the logger level" do
         logger.add(Lumberjack::Severity::DEBUG, "debug")
         logger.add(Lumberjack::Severity::INFO, "info")
         logger.add(Lumberjack::Severity::ERROR, "error")
         output.string.should == "info#{n}error#{n}"
       end
-    
+
       it "should only log fatal messages when the level is set to fatal" do
         logger.level = Lumberjack::Severity::FATAL
         logger.fatal("fatal")
@@ -304,7 +313,7 @@ describe Lumberjack::Logger do
         logger.unknown("unknown")
         output.string.should == "fatal#{n}unknown#{n}"
       end
-    
+
       it "should only log error messages and higher when the level is set to error" do
         logger.level = Lumberjack::Severity::ERROR
         logger.fatal("fatal")
@@ -320,7 +329,7 @@ describe Lumberjack::Logger do
         logger.unknown("unknown")
         output.string.should == "fatal#{n}error#{n}unknown#{n}"
       end
-    
+
       it "should only log warn messages and higher when the level is set to warn" do
         logger.level = Lumberjack::Severity::WARN
         logger.fatal("fatal")
@@ -336,7 +345,7 @@ describe Lumberjack::Logger do
         logger.unknown("unknown")
         output.string.should == "fatal#{n}error#{n}warn#{n}unknown#{n}"
       end
-    
+
       it "should only log info messages and higher when the level is set to info" do
         logger.level = Lumberjack::Severity::INFO
         logger.fatal("fatal")
@@ -352,7 +361,7 @@ describe Lumberjack::Logger do
         logger.unknown("unknown")
         output.string.should == "fatal#{n}error#{n}warn#{n}info#{n}unknown#{n}"
       end
-    
+
       it "should log all messages when the level is set to debug" do
         logger.level = Lumberjack::Severity::DEBUG
         logger.fatal("fatal")
@@ -368,7 +377,7 @@ describe Lumberjack::Logger do
         logger.unknown("unknown")
         output.string.should == "fatal#{n}error#{n}warn#{n}info#{n}debug#{n}unknown#{n}"
       end
-  
+
       it "should only log unkown messages when the level is set above fatal" do
         logger.level = Lumberjack::Severity::FATAL + 1
         logger.fatal("fatal")


### PR DESCRIPTION
The Logger from the ruby standard library will use the program name as
the message if both a message and block are missing.

The docs define `progname` as:

> Program name string. Can be omitted. Treated as a message if no
> `message` and `block` are given.

It looks like they created it this way to facilitate the severity methods, i.e.,

``` ruby
def info(progname = nil, &block)
  add(INFO, nil, progname, &block)
end
```

This pull request brings lumberjack in conformity with the ruby logger, for better or worse.
