### PR TITLE
Deleted an unused variable that was throwing warnings

### DIFF
--- a/lib/lumberjack/device/size_rolling_log_file.rb
+++ b/lib/lumberjack/device/size_rolling_log_file.rb
@@ -38,7 +38,7 @@ module Lumberjack
 
       def roll_file?
         stream.stat.size > @max_size
-      rescue SystemCallError => e
+      rescue SystemCallError
         false
       end
       


### PR DESCRIPTION
Every time I run my tests with the default Hoe minitest plugin it throws up a warning saying that this variable `e` was not used. It's not used, so I thought why not get rid of it.