### PR TITLE
Mixing strings with different encodings may cause #flush call to raise an error.

### DIFF
--- a/lib/lumberjack/device/log_file.rb
+++ b/lib/lumberjack/device/log_file.rb
@@ -4,6 +4,8 @@ module Lumberjack
   class Device
     # This is a logging device that appends log entries to a file.
     class LogFile < Writer
+      EXTERNAL_ENCODING = "ascii-8bit"
+
       # The absolute path of the file being logged to.
       attr_reader :path
       
@@ -11,7 +13,7 @@ module Lumberjack
       def initialize(path, options = {})
         @path = File.expand_path(path)
         FileUtils.mkdir_p(File.dirname(@path))
-        super(File.new(@path, 'a', :encoding => "ascii-8bit"), options)
+        super(File.new(@path, 'a', :encoding => EXTERNAL_ENCODING), options)
       end
     end
   end

--- a/lib/lumberjack/device/rolling_log_file.rb
+++ b/lib/lumberjack/device/rolling_log_file.rb
@@ -51,7 +51,7 @@ module Lumberjack
 
       def reopen_file
         old_stream = stream
-        self.stream = File.open(path, 'a')
+        self.stream = File.open(path, 'a', encoding: EXTERNAL_ENCODING)
         stream.sync = true
         @file_inode = stream.lstat.ino rescue nil
         old_stream.close

--- a/lib/lumberjack/device/writer.rb
+++ b/lib/lumberjack/device/writer.rb
@@ -19,7 +19,11 @@ module Lumberjack
         end
         
         def <<(string)
-          @values << string
+          @values << string.encode(
+            "UTF-8",
+            invalid: :replace,
+            undef: :replace
+          )
           @size += string.size
         end
         

--- a/spec/device/log_file_spec.rb
+++ b/spec/device/log_file_spec.rb
@@ -23,4 +23,19 @@ describe Lumberjack::Device::LogFile do
     File.read(log_file).should == "Existing contents\nNew log entry#{Lumberjack::LINE_SEPARATOR}"
   end
 
+  it "properly handles messages with broken UTF-8 characters" do
+    log_file = File.join(tmp_dir, "test_6.log")
+    device = Lumberjack::Device::LogFile.new(log_file,
+      :keep => 2, :buffer_size => 32767)
+
+    message = [0xC4, 0x90, 0xE1, 0xBB].pack("c*").force_encoding "ASCII-8BIT"
+    entry = Lumberjack::LogEntry.new(Time.now, 1, message, nil, $$, nil)
+    device.write entry
+
+    message = "message"
+    entry = Lumberjack::LogEntry.new(Time.now, 1, message, nil, $$, nil)
+    device.write entry
+
+    device.flush
+  end
 end

--- a/spec/device/log_file_spec.rb
+++ b/spec/device/log_file_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'spec_helper'
 
 describe Lumberjack::Device::LogFile do
@@ -32,10 +33,12 @@ describe Lumberjack::Device::LogFile do
     entry = Lumberjack::LogEntry.new(Time.now, 1, message, nil, $$, nil)
     device.write entry
 
-    message = "message"
+    message = "проверка"
     entry = Lumberjack::LogEntry.new(Time.now, 1, message, nil, $$, nil)
     device.write entry
 
-    device.flush
+    expect do
+      device.flush
+    end.to_not raise_error
   end
 end

--- a/spec/device/rolling_log_file_spec.rb
+++ b/spec/device/rolling_log_file_spec.rb
@@ -125,4 +125,26 @@ describe Lumberjack::Device::RollingLogFile do
     Dir.glob("#{log_file}*").sort.should == [log_file, "#{log_file}.another", "#{log_file}.keep"]
   end
 
+  context "when file is rolled" do
+    let(:log_file) { File.join(tmp_dir, "test_6.log") }
+
+    let(:device) do
+      device = Lumberjack::Device::RollingLogFile.new(log_file, :template => ":message", :keep => 2, :buffer_size => 32767)
+      device.stub(:roll_file?).and_return(true)
+      device.stub(:archive_file_suffix => "rolled")
+      device
+    end
+
+    before do
+      device.write(entry)
+      device.flush
+    end
+
+    it "reopens file with proper encoding" do
+      encoding = device.send(:stream).external_encoding
+      expect(encoding).to_not be_nil
+      expect(encoding.name).to eq "ASCII-8BIT"
+    end
+  end
+
 end


### PR DESCRIPTION
Suggested fix for #21