### PR TITLE
warning: assigned but unused variable - e

### DIFF
--- a/lib/lumberjack/device/size_rolling_log_file.rb
+++ b/lib/lumberjack/device/size_rolling_log_file.rb
@@ -38,7 +38,7 @@ module Lumberjack
 
       def roll_file?
         stream.stat.size > @max_size
-      rescue SystemCallError => e
+      rescue SystemCallError
         false
       end
       


### PR DESCRIPTION
ruby warns that this variable `e` is not in use.