### PR TITLE
Remove unused variable to silence warnings

### DIFF
--- a/lib/lumberjack/device/size_rolling_log_file.rb
+++ b/lib/lumberjack/device/size_rolling_log_file.rb
@@ -38,7 +38,7 @@ module Lumberjack
 
       def roll_file?
         stream.stat.size > @max_size
-      rescue SystemCallError => e
+      rescue SystemCallError
         false
       end
       


### PR DESCRIPTION
The modified line causes an `assigned but unused variable` warning when Ruby is called with the `-w` option (which needlessly clutters test reports).