### PR TITLE
date_rolling_log_file: compare dates with != instead of >.

### DIFF
--- a/lib/lumberjack/device/date_rolling_log_file.rb
+++ b/lib/lumberjack/device/date_rolling_log_file.rb
@@ -37,11 +37,11 @@ module Lumberjack
         date = Date.today
         if date.year > @file_date.year
           true
-        elsif @roll_period == :daily && date.yday > @file_date.yday
+        elsif @roll_period == :daily && date.yday != @file_date.yday
           true
-        elsif @roll_period == :weekly && date.cweek > @file_date.cweek
+        elsif @roll_period == :weekly && date.cweek != @file_date.cweek
           true
-        elsif @roll_period == :monthly && date.month > @file_date.month
+        elsif @roll_period == :monthly && date.month != @file_date.month
           true
         else
           false


### PR DESCRIPTION
Hi,

`lumberjack` has been packaged in the GNU Guix package manager, where we run unit tests, and I came across this issue.
```
/gnu/store/ippi1rw3869rzv21v3ixvzrim40r2s02-ruby-2.2.3/bin/ruby -I/gnu/store/8mp9yjk9ij8ypck9mq8cl09fsvz2ps1p-ruby-rspec-support-3.2.2/lib/ruby/gems/2.2.0/gems/rspec-support-3.2.2/lib:/gnu/store/gigv44i4x36d3fr8wh578vxv6wf077yx-ruby-rspec-core-3.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.2.3/lib /gnu/store/gigv44i4x36d3fr8wh578vxv6wf077yx-ruby-rspec-core-3.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.2.3/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.F.............................................................................................

Failures:

  1) Lumberjack::Device::DateRollingLogFile should roll the file weekly
     Failure/Error: File.read("#{log_file}.#{today.strftime('week-of-%Y-%m-%d')}").should == "test week one#{Lumberjack::LINE_SEPARATOR}"
     Errno::ENOENT:
       No such file or directory @ rb_sysopen - /tmp/nix-build-ruby-lumberjack-1.0.9.drv-0/gem/spec/tmp/b731195059.log.week-of-2016-01-02
     # ./spec/device/date_rolling_log_file_spec.rb:45:in `read'
     # ./spec/device/date_rolling_log_file_spec.rb:45:in `block (2 levels) in <top (required)>'
```
This issue has been fixed in the attached pull request.

I also encourage you to make the tests not rely on the current time/date and instead use stubs. This helps makes the process of building and testing deterministic, which is important for reproducibility.

Thanks
ben