### PR TITLE
Fix/flatten `files` field in gemspec

### DIFF
--- a/lumberjack.gemspec
+++ b/lumberjack.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email = ['bbdurand@gmail.com']
   s.homepage = "http://github.com/bdurand/lumberjack"
 
-  s.files = ['README.rdoc', 'VERSION', 'Rakefile', 'MIT_LICENSE'] +  Dir.glob('lib/**/*'), Dir.glob('spec/**/*')
+  s.files = ['README.rdoc', 'VERSION', 'Rakefile', 'MIT_LICENSE'].concat(Dir.glob('lib/**/*')).concat(Dir.glob('spec/**/*'))
   s.require_path = 'lib'
   
   s.has_rdoc = true


### PR DESCRIPTION
This can crash bundler, because Bundler expects a flat array.
