### PR TITLE
Fix deprecated_warning for Integer Unification

### DIFF
--- a/lib/lumberjack/log_entry.rb
+++ b/lib/lumberjack/log_entry.rb
@@ -8,7 +8,7 @@ module Lumberjack
     
     def initialize(time, severity, message, progname, pid, unit_of_work_id)
       @time = time
-      @severity = (severity.is_a?(Fixnum) ? severity : Severity.label_to_level(severity))
+      @severity = (severity.is_a?(Integer) ? severity : Severity.label_to_level(severity))
       @message = message
       @progname = progname
       @pid = pid

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -200,7 +200,7 @@ module Lumberjack
 
     # Set the minimum level of severity of messages to log.
     def level=(severity)
-      if severity.is_a?(Fixnum)
+      if severity.is_a?(Integer)
         @level = severity
       else
         @level = Severity.label_to_level(severity)

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -32,7 +32,7 @@ describe Lumberjack::Formatter do
   
   it "should format an object based on the class hierarchy" do
     formatter.add(Numeric){|obj| "number: #{obj}"}
-    formatter.add(Fixnum){|obj| "fixed number: #{obj}"}
+    formatter.add(Integer){|obj| "fixed number: #{obj}"}
     formatter.format(10).should == "fixed number: 10"
     formatter.format(10.1).should == "number: 10.1"
   end


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warning in Ruby 2.4.0-rc1.

`warning: constant ::Fixnum is deprecated`

Thanks.