### PR TITLE
Specify `--require spec_helper` in .rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/device/date_rolling_log_file_spec.rb
+++ b/spec/device/date_rolling_log_file_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Device::DateRollingLogFile do
 
   before :all do

--- a/spec/device/log_file_spec.rb
+++ b/spec/device/log_file_spec.rb
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-require 'spec_helper'
-
 describe Lumberjack::Device::LogFile do
 
   before :all do

--- a/spec/device/null_spec.rb
+++ b/spec/device/null_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Device::Null do
 
   it "should not generate any output" do

--- a/spec/device/rolling_log_file_spec.rb
+++ b/spec/device/rolling_log_file_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Device::RollingLogFile do
 
   before :all do

--- a/spec/device/size_rolling_log_file_spec.rb
+++ b/spec/device/size_rolling_log_file_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Device::SizeRollingLogFile do
 
   before :all do

--- a/spec/device/writer_spec.rb
+++ b/spec/device/writer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Device::Writer do
 
   let(:time_string){ "2011-01-15T14:23:45.123" }

--- a/spec/formatter/exception_formatter_spec.rb
+++ b/spec/formatter/exception_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Formatter::ExceptionFormatter do
 
   it "should convert an exception without a backtrace to a string" do

--- a/spec/formatter/inspect_formatter_spec.rb
+++ b/spec/formatter/inspect_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Formatter::InspectFormatter do
 
   it "should format objects as string by calling their inspect method" do

--- a/spec/formatter/pretty_print_formatter_spec.rb
+++ b/spec/formatter/pretty_print_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Formatter::PrettyPrintFormatter do
 
   it "should convert an object to a string using pretty print" do

--- a/spec/formatter/string_formatter_spec.rb
+++ b/spec/formatter/string_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Formatter::StringFormatter do
 
   it "should format objects as string by calling their to_s method" do

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Formatter do
 
   let(:formatter){ Lumberjack::Formatter.new }

--- a/spec/log_entry_spec.rb
+++ b/spec/log_entry_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::LogEntry do
   
   it "should have a time" do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'pathname'
 
 describe Lumberjack::Logger do

--- a/spec/lumberjack_spec.rb
+++ b/spec/lumberjack_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack do
   
   context "unit of work" do

--- a/spec/rack/unit_of_work_spec.rb
+++ b/spec/rack/unit_of_work_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Rack::UnitOfWork do
  
   it "should create a unit of work in a middleware stack" do

--- a/spec/severity_spec.rb
+++ b/spec/severity_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Severity do
   
   it "should convert a level to a label" do

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Lumberjack::Template do
   
   let(:time_string){ "2011-01-15T14:23:45.123" }


### PR DESCRIPTION
Require `spec_helper` automatically in `*_spec.rb`. I think that it's a [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself) way.