### PR TITLE
ActiveSupport::TaggedLogging and Lumberjack stack level too deep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'pry-byebug'
+gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,11 +6,35 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
+    byebug (11.1.1)
+    coderay (1.1.2)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
+    ffi (1.12.2-java)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    method_source (0.9.2)
+    minitest (5.14.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry (0.12.2-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+      spoon (~> 0.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     rake (13.0.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -25,16 +49,25 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
+    spoon (0.0.6)
+      ffi
     thor (1.0.1)
+    thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     timecop (0.9.1)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   java
   ruby
 
 DEPENDENCIES
+  activesupport
   appraisal
   lumberjack!
+  pry-byebug
   rake
   rspec (~> 3.0)
   timecop

--- a/spec/tagged_logger_support_spec.rb
+++ b/spec/tagged_logger_support_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "active_support"
 
 describe Lumberjack::TaggedLoggerSupport do
   let(:output){ StringIO.new }
@@ -6,6 +7,11 @@ describe Lumberjack::TaggedLoggerSupport do
   let(:logger){ Lumberjack::Logger.new(device).tagged_logger! }
 
   describe "logger" do
+    it 'should not stack level too deep' do
+      tagged_logger = ActiveSupport::TaggedLogging.new(logger)
+      tagged_logger.tagged("foo") { }
+    end
+
     describe "tagged" do
       it "should add tags to the tag 'tagged'" do
         logger.tagged("foo", "bar") do


### PR DESCRIPTION
# What this PR does

Hello @bdurand. This PR recreates a stack level too deep error  myself and @icorson3 ran into today when updating lumberjack to 1.2.0, 1.2.1, 1.2.2, and 1.2.3.

This change-set doesn't fix anything. We're not sure if this should be fixed in lumberjack, in our app, etc. This is more of a "Hey, this seems like a problem, is lumberjack supposed to be playing nicely with ActiveSupported::TaggedLogging OR is this not the correct usage?" kind of thing.

## The problem

When an ActiveSupport::TaggedLogger wraps a Lumberjack::Logger it creates a recursive call on tagged due to this method being included on the logger object in active support: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/tagged_logging.rb#L85-L87

## Why this problem existed for us

This problem occurred due to webpacker loading and hitting this line: https://github.com/rails/webpacker/blob/master/lib/webpacker/railtie.rb#L77

It looks like when this line was hit our Rails.logger (which is a Lumberjack::Logger) hadn't been converted to tagged logger in lumber jack which set this up for problems later on when it was converted to a tagged logger.

Let us know if any questions. Thanks!