### PR TITLE
Fix magic comments (DO NOT MERGE)

### DIFF
--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 require "rbconfig"
 require "time"

--- a/lib/lumberjack/device.rb
+++ b/lib/lumberjack/device.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   # This is an abstract class for logging devices. Subclasses must implement the +write+ method and

--- a/lib/lumberjack/device/date_rolling_log_file.rb
+++ b/lib/lumberjack/device/date_rolling_log_file.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 require "date"
 

--- a/lib/lumberjack/device/log_file.rb
+++ b/lib/lumberjack/device/log_file.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 require "fileutils"
 

--- a/lib/lumberjack/device/multi.rb
+++ b/lib/lumberjack/device/multi.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Device

--- a/lib/lumberjack/device/null.rb
+++ b/lib/lumberjack/device/null.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Device

--- a/lib/lumberjack/device/rolling_log_file.rb
+++ b/lib/lumberjack/device/rolling_log_file.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Device

--- a/lib/lumberjack/device/size_rolling_log_file.rb
+++ b/lib/lumberjack/device/size_rolling_log_file.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Device

--- a/lib/lumberjack/device/writer.rb
+++ b/lib/lumberjack/device/writer.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Device

--- a/lib/lumberjack/formatter.rb
+++ b/lib/lumberjack/formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   # This class controls the conversion of log entry messages into a loggable format. This allows you

--- a/lib/lumberjack/formatter/date_time_formatter.rb
+++ b/lib/lumberjack/formatter/date_time_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Formatter

--- a/lib/lumberjack/formatter/exception_formatter.rb
+++ b/lib/lumberjack/formatter/exception_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Formatter

--- a/lib/lumberjack/formatter/id_formatter.rb
+++ b/lib/lumberjack/formatter/id_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Formatter

--- a/lib/lumberjack/formatter/inspect_formatter.rb
+++ b/lib/lumberjack/formatter/inspect_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Formatter

--- a/lib/lumberjack/formatter/object_formatter.rb
+++ b/lib/lumberjack/formatter/object_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Formatter

--- a/lib/lumberjack/formatter/pretty_print_formatter.rb
+++ b/lib/lumberjack/formatter/pretty_print_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 require "pp"
 require "stringio"

--- a/lib/lumberjack/formatter/string_formatter.rb
+++ b/lib/lumberjack/formatter/string_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Formatter

--- a/lib/lumberjack/formatter/strip_formatter.rb
+++ b/lib/lumberjack/formatter/strip_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Formatter

--- a/lib/lumberjack/formatter/structured_formatter.rb
+++ b/lib/lumberjack/formatter/structured_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 require "set"
 

--- a/lib/lumberjack/formatter/truncate_formatter.rb
+++ b/lib/lumberjack/formatter/truncate_formatter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   class Formatter

--- a/lib/lumberjack/log_entry.rb
+++ b/lib/lumberjack/log_entry.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   # An entry in a log is a data structure that captures the log message as well as

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   # Logger is a thread safe logging object. It has a compatible API with the Ruby

--- a/lib/lumberjack/rack.rb
+++ b/lib/lumberjack/rack.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   module Rack

--- a/lib/lumberjack/rack/context.rb
+++ b/lib/lumberjack/rack/context.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   module Rack

--- a/lib/lumberjack/rack/request_id.rb
+++ b/lib/lumberjack/rack/request_id.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   module Rack

--- a/lib/lumberjack/rack/unit_of_work.rb
+++ b/lib/lumberjack/rack/unit_of_work.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   module Rack

--- a/lib/lumberjack/severity.rb
+++ b/lib/lumberjack/severity.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   # The standard severity levels for logging messages.

--- a/lib/lumberjack/template.rb
+++ b/lib/lumberjack/template.rb
@@ -1,4 +1,4 @@
-# frozen_string_literals: true
+# frozen_string_literal: true
 
 module Lumberjack
   # A template converts entries to strings. Templates can contain the following place holders to


### PR DESCRIPTION
Many files in this repo have the magic comment `frozen_string_literals: true`, but this is invalid, it should be `frozen_string_literal: true` (no plural). However, the specs fail when this is changed so more work will be needed to address this.