### PR TITLE
Fix frozen_string_literals invalid magic comments

### DIFF
--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 require "rbconfig"
 require "time"
 require "securerandom"

--- a/lib/lumberjack/device.rb
+++ b/lib/lumberjack/device.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   # This is an abstract class for logging devices. Subclasses must implement the +write+ method and
   # may implement the +close+ and +flush+ methods if applicable.

--- a/lib/lumberjack/device/date_rolling_log_file.rb
+++ b/lib/lumberjack/device/date_rolling_log_file.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 require "date"
 
 module Lumberjack

--- a/lib/lumberjack/device/log_file.rb
+++ b/lib/lumberjack/device/log_file.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 require "fileutils"
 
 module Lumberjack

--- a/lib/lumberjack/device/multi.rb
+++ b/lib/lumberjack/device/multi.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Device
     # This is a logging device that forward log entries to multiple other devices.

--- a/lib/lumberjack/device/null.rb
+++ b/lib/lumberjack/device/null.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Device
     # This is a logging device that produces no output. It can be useful in

--- a/lib/lumberjack/device/rolling_log_file.rb
+++ b/lib/lumberjack/device/rolling_log_file.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Device
     # This is an abstract class for a device that appends entries to a file and periodically archives

--- a/lib/lumberjack/device/size_rolling_log_file.rb
+++ b/lib/lumberjack/device/size_rolling_log_file.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Device
     # This is a log device that appends entries to a file and rolls the file when it reaches a specified

--- a/lib/lumberjack/device/writer.rb
+++ b/lib/lumberjack/device/writer.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Device
     # This logging device writes log entries as strings to an IO stream. By default, messages will be buffered

--- a/lib/lumberjack/formatter.rb
+++ b/lib/lumberjack/formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   # This class controls the conversion of log entry messages into a loggable format. This allows you
   # to log any object you want and have the logging system deal with converting it into a string.

--- a/lib/lumberjack/formatter/date_time_formatter.rb
+++ b/lib/lumberjack/formatter/date_time_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Formatter
     # Format a Date, Time, or DateTime object. If you don't specify a format in the constructor,

--- a/lib/lumberjack/formatter/exception_formatter.rb
+++ b/lib/lumberjack/formatter/exception_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Formatter
     # Format an exception including the backtrace. You can specify an object that

--- a/lib/lumberjack/formatter/id_formatter.rb
+++ b/lib/lumberjack/formatter/id_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Formatter
     # Format an object that has an id as a hash with keys for class and id. This formatter is useful

--- a/lib/lumberjack/formatter/inspect_formatter.rb
+++ b/lib/lumberjack/formatter/inspect_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Formatter
     # Format an object by calling +inspect+ on it.

--- a/lib/lumberjack/formatter/object_formatter.rb
+++ b/lib/lumberjack/formatter/object_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Formatter
     # No-op formatter that just returns the object itself.

--- a/lib/lumberjack/formatter/pretty_print_formatter.rb
+++ b/lib/lumberjack/formatter/pretty_print_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 require "pp"
 require "stringio"
 

--- a/lib/lumberjack/formatter/string_formatter.rb
+++ b/lib/lumberjack/formatter/string_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Formatter
     # Format an object by calling `to_s` on it.

--- a/lib/lumberjack/formatter/strip_formatter.rb
+++ b/lib/lumberjack/formatter/strip_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Formatter
     # Format an object by calling `to_s` on it and stripping leading and trailing whitespace.

--- a/lib/lumberjack/formatter/structured_formatter.rb
+++ b/lib/lumberjack/formatter/structured_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 require "set"
 
 module Lumberjack

--- a/lib/lumberjack/formatter/truncate_formatter.rb
+++ b/lib/lumberjack/formatter/truncate_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   class Formatter
     # Truncate a string object to a specific length. This is useful

--- a/lib/lumberjack/log_entry.rb
+++ b/lib/lumberjack/log_entry.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   # An entry in a log is a data structure that captures the log message as well as
   # information about the system that logged the message.

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   # Logger is a thread safe logging object. It has a compatible API with the Ruby
   # standard library Logger class, the Log4r gem, and ActiveSupport::BufferedLogger.

--- a/lib/lumberjack/rack.rb
+++ b/lib/lumberjack/rack.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   module Rack
     require_relative "rack/unit_of_work"

--- a/lib/lumberjack/rack/context.rb
+++ b/lib/lumberjack/rack/context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   module Rack
     # Middleware to create a global context for Lumberjack for the scope of a rack request.

--- a/lib/lumberjack/rack/request_id.rb
+++ b/lib/lumberjack/rack/request_id.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   module Rack
     # Support for using the Rails ActionDispatch request id in the log.

--- a/lib/lumberjack/rack/unit_of_work.rb
+++ b/lib/lumberjack/rack/unit_of_work.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   module Rack
     class UnitOfWork

--- a/lib/lumberjack/severity.rb
+++ b/lib/lumberjack/severity.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   # The standard severity levels for logging messages.
   module Severity

--- a/lib/lumberjack/template.rb
+++ b/lib/lumberjack/template.rb
@@ -1,5 +1,3 @@
-# frozen_string_literals: true
-
 module Lumberjack
   # A template converts entries to strings. Templates can contain the following place holders to
   # reference log entry values:


### PR DESCRIPTION
`# frozen_string_literals: true`
should be
`# frozen_string_literal: true`

The invalid magic comment causes  [Ruby LSP](https://github.com/Shopify/ruby-lsp) to segfault on startup when Lumberjack is in the Gemfile.lock.

Since the tests fail when I replace `frozen_string_literals` with the correct `frozen_string_literal`, I simply removed the invalid magic comment from the affected files. My reasoning is that this magic comment was doing nothing at the moment, so removing it does not change anything functionally.

