### PR TITLE
Added helper methods for generating global PIDs and thread IDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for setting tags from the request environment in `Lumberjack::Rack::Context` middleware.
 - Added helper methods to generate global PID's and thread ids.
 - Added `Lumberjack::Logger#tag_globally` to explicitly set a global tag for all loggers.
+- Added `Lumberjack::Logger#tag_value` to get the value of a tag by name from the current tag context.
 - Added `Lumberjack::Utils.hostname` to get the hostname in UTF-8 encoding.
 - Added `Lumberjack::Utils.global_pid` to get a global process id in a consistent format.
 - Added `Lumberjack::Utils.global_thread_id` to get a thread id in a consistent format.
 - Added `Lumberjack::Utils.thread_name` to get a thread name in a consistent format.
+- Added support for `ActiveSupport::Logging.logger_outputs_to?` to check if a logger is outputting to a specific IO stream.
+- Added `Lumberjack::Logger#log_at` method to temporarily set the log level for a block of code for compatibility with ActiveSupport loggers.
 
 ### Changed
 
 - Default date/time format for log entries is now ISO-8601 with microsecond precision.
+- Tags that are set to hash values will now be flattened into dot-separated keys in templates.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apply formatters to enumerable values in tags. Name formatters are applied using dot syntax when a tag value contains a hash.
 - Added support for a dedicated message formatter that can override the default formatter on the log message.
 - Added support for setting tags from the request environment in `Lumberjack::Rack::Context` middleware.
+- Added helper methods to generate global PID's and thread ids.
+- Added `Lumberjack::Logger#tag_globally` to explicitly set a global tag for all loggers.
+- Added `Lumberjack::Utils.hostname` to get the hostname in UTF-8 encoding.
+- Added `Lumberjack::Utils.global_pid` to get a global process id in a consistent format.
+- Added `Lumberjack::Utils.global_thread_id` to get a thread id in a consistent format.
+- Added `Lumberjack::Utils.thread_name` to get a thread name in a consistent format.
+
+### Changed
+
+- Default date/time format for log entries is now ISO-8601 with microsecond precision.
 
 ### Removed
 
@@ -23,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - All unit of work related functionality from version 1.0 has been officially deprecated and will be removed in version 2.0. Use tags instead to set a global context for log entries.
+- Calling `Lumberjack::Logger#tag` without a block is deprecated. Use `Lumberjack::Logger#tag_globally` instead.
 
 ## 1.2.10
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ When a Logger logs a LogEntry, it sends it to a Lumberjack::Device. Lumberjack c
 If you'd like to send your log to a different kind of output, you just need to extend the Device class and implement the `write` method. Or check out these plugins:
 
 - [lumberjack_json_device](https://github.com/bdurand/lumberjack_json_device) - output your log messages as stream of JSON objects for structured logging.
-- [lumberjack_data_dog_device](https://github.com/bdurand/lumberjack_data_dog_device) - output log messages using the [DataDog standard attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/).
-- [lumberjack_ecs_device](https://github.com/bdurand/lumberjack_ecs_device) - output log messages using the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html) format.
 - [lumberjack_syslog_device](https://github.com/bdurand/lumberjack_syslog_device) - send your log messages to the system wide syslog service
 - [lumberjack_mongo_device](https://github.com/bdurand/lumberjack_mongo_device) - store your log messages to a [MongoDB](http://www.mongodb.org/) NoSQL data store
 - [lumberjack_redis_device](https://github.com/bdurand/lumberjack_redis_device) - store your log messages in a [Redis](https://redis.io/) data store
@@ -303,6 +301,14 @@ The built in stream based logging devices use an internal buffer. The size of th
 The built in devices include two that can automatically roll log files based either on date or on file size. When a log file is rolled, it will be renamed with a suffix and a new file will be created to receive new log entries. This can keep your log files from growing to unusable sizes and removes the need to schedule an external process to roll the files.
 
 There is a similar feature in the standard library Logger class, but the implementation here is safe to use with multiple processes writing to the same log file.
+
+## Integrations
+
+Lumberjack has built in support for logging extensions in Rails.
+
+You can use the [`lumberjack_sidekiq`](https://github.com/bdurand/lumberjack_sidekiq) gem to replace Sidekiq's default logger with Lumberjack. This allows you to use all of Lumberjack's features, such as structured logging and tag support, in your Sidekiq jobs.
+
+If you are using DataDog for logging, you can use the [`lumberjack_data_dog`](https://github.com/bdurand/lumberjack_data_dog) gem to format your logs in DataDog's standard attributes format.
 
 ## Differences from Standard Library Logger
 

--- a/README.md
+++ b/README.md
@@ -372,12 +372,12 @@ To send log messages to syslog instead of to a file, you could use this (require
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'lumberjack'
+gem "lumberjack"
 ```
 
 And then execute:
 ```bash
-$ bundle
+$ bundle install
 ```
 
 Or install it yourself as:

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -22,6 +22,7 @@ module Lumberjack
   require_relative "lumberjack/tagged_logging"
   require_relative "lumberjack/template"
   require_relative "lumberjack/rack"
+  require_relative "lumberjack/utils"
 
   class << self
     # Define a unit of work within a block. Within the block supplied to this
@@ -38,10 +39,12 @@ module Lumberjack
     # @return [void]
     # @deprecated Use tags instead. This will be removed in version 2.0.
     def unit_of_work(id = nil)
-      id ||= SecureRandom.hex(6)
-      context do
-        context[:unit_of_work_id] = id
-        yield
+      Lumberjack::Utils.deprecated("Lumberjack.unit_of_work", "Lumberjack.unit_of_work will be removed in version 2.0. Use Lumberjack::Logger#tag(unit_of_work: id) instead.") do
+        id ||= SecureRandom.hex(6)
+        context do
+          context[:unit_of_work_id] = id
+          yield
+        end
       end
     end
 

--- a/lib/lumberjack/device/writer.rb
+++ b/lib/lumberjack/device/writer.rb
@@ -149,6 +149,13 @@ module Lumberjack
         end
       end
 
+      # Return the underlying stream. Provided for API compatibility with Logger devices.
+      #
+      # @return [IO] The underlying stream.
+      def dev
+        @stream
+      end
+
       protected
 
       # Set the underlying stream.

--- a/lib/lumberjack/formatter/date_time_formatter.rb
+++ b/lib/lumberjack/formatter/date_time_formatter.rb
@@ -16,7 +16,7 @@ module Lumberjack
         if @format && obj.respond_to?(:strftime)
           obj.strftime(@format)
         elsif obj.respond_to?(:iso8601)
-          obj.iso8601
+          obj.iso8601(6)
         else
           obj.to_s
         end

--- a/lib/lumberjack/log_entry.rb
+++ b/lib/lumberjack/log_entry.rb
@@ -47,15 +47,19 @@ module Lumberjack
 
     # @deprecated - backward compatibility with 1.0 API. Will be removed in version 2.0.
     def unit_of_work_id
-      tags[UNIT_OF_WORK_ID] if tags
+      Lumberjack::Utils.deprecated("Lumberjack::LogEntry#unit_of_work_id", "Lumberjack::LogEntry#unit_of_work_id will be removed in version 2.0") do
+        tags[UNIT_OF_WORK_ID] if tags
+      end
     end
 
     # @deprecated - backward compatibility with 1.0 API. Will be removed in version 2.0.
     def unit_of_work_id=(value)
-      if tags
-        tags[UNIT_OF_WORK_ID] = value
-      else
-        @tags = {UNIT_OF_WORK_ID => value}
+      Lumberjack::Utils.deprecated("Lumberjack::LogEntry#unit_of_work_id=", "Lumberjack::LogEntry#unit_of_work_id= will be removed in version 2.0") do
+        if tags
+          tags[UNIT_OF_WORK_ID] = value
+        else
+          @tags = {UNIT_OF_WORK_ID => value}
+        end
       end
     end
 

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -96,10 +96,8 @@ module Lumberjack
     # @param [Lumberjack::Device] device The new logging device.
     # @return [void]
     def device=(device)
-      if device
-        @logdev = open_device(device, options)
-      else
-        @logdev = nil
+      @logdev = if device
+        open_device(device, options)
       end
     end
 
@@ -573,7 +571,7 @@ module Lumberjack
 
       flattened_tags.keys.select { |key| key.include?(".") }.each do |key|
         parts = key.split(".")
-        while subkey = parts.pop do
+        while (subkey = parts.pop)
           flattened_tags[parts.join(".")] = {subkey => flattened_tags[(parts + [subkey]).join(".")]}
         end
       end

--- a/lib/lumberjack/rack/request_id.rb
+++ b/lib/lumberjack/rack/request_id.rb
@@ -11,8 +11,10 @@ module Lumberjack
       REQUEST_ID = "action_dispatch.request_id"
 
       def initialize(app, abbreviated = false)
-        @app = app
-        @abbreviated = abbreviated
+        Lumberjack::Utils.deprecated("Lumberjack::Rack::RequestId", "Lumberjack::Rack::RequestId will be removed in version 2.0") do
+          @app = app
+          @abbreviated = abbreviated
+        end
       end
 
       def call(env)

--- a/lib/lumberjack/rack/unit_of_work.rb
+++ b/lib/lumberjack/rack/unit_of_work.rb
@@ -6,7 +6,9 @@ module Lumberjack
     # with an identifier to tie log entries together in a unit of work. Will be removed in version 2.0.
     class UnitOfWork
       def initialize(app)
-        @app = app
+        Lumberjack::Utils.deprecated("Lumberjack::Rack::UnitOfWork", "Lumberjack::Rack::UnitOfWork will be removed in version 2.0") do
+          @app = app
+        end
       end
 
       def call(env)

--- a/lib/lumberjack/tagged_logger_support.rb
+++ b/lib/lumberjack/tagged_logger_support.rb
@@ -46,7 +46,12 @@ module Lumberjack
         tagged_values = Array(tag_hash["tagged"] || self.tags["tagged"])
         tag_hash["tagged"] = tagged_values + [tag]
       end
-      tag(tag_hash, &block)
+
+      if block || in_tag_context?
+        tag(tag_hash, &block)
+      else
+        tag_globally(tag_hash)
+      end
     end
 
     def push_tags(*tags)

--- a/lib/lumberjack/template.rb
+++ b/lib/lumberjack/template.rb
@@ -99,7 +99,7 @@ module Lumberjack
       return [nil] * (tag_vars.size + 1) if tags.nil? || tags.size == 0
 
       tags_string = +""
-      tags.each do |name, value|
+      Lumberjack::Utils.flatten_tags(tags).each do |name, value|
         unless value.nil? || tag_vars.include?(name)
           value = value.to_s
           value = value.gsub(Lumberjack::LINE_SEPARATOR, " ") if value.include?(Lumberjack::LINE_SEPARATOR)

--- a/lib/lumberjack/utils.rb
+++ b/lib/lumberjack/utils.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "socket"
+
+module Lumberjack
+  module Utils
+    UNDEFINED = Object.new.freeze
+    private_constant :UNDEFINED
+
+    NON_SLUGGABLE_PATTERN = /[^A-Za-z0-9_.-]+/.freeze
+    private_constant :NON_SLUGGABLE_PATTERN
+
+    @deprecations = nil
+    @deprecations_lock = nil
+    @hostname = UNDEFINED
+
+    class << self
+      # Print warning when deprecated methods are called the first time.
+      #
+      # @param method [String] The name of the deprecated method.
+      # @param message [String] Optional message to include in the warning.
+      # @yield The block to execute after the warning.
+      def deprecated(method, message)
+        @deprecations_lock ||= Mutex.new
+        unless @deprecations&.include?(method)
+          @deprecations_lock.synchronize do
+            @deprecations ||= {}
+            unless @deprecations.include?(method)
+              trace = caller_locations[2, 2].last
+              message = "DEPRECATION WARNING: #{message} Called from #{trace.path}:#{trace.lineno}."
+              @deprecations[method] = true
+              warn(message) unless ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"] == "true"
+            end
+          end
+        end
+
+        yield
+      end
+
+      # Get the hostname of the machine. The returned value will be in UTF-8 encoding.
+      #
+      # @return [String] The hostname of the machine.
+      def hostname
+        if @hostname.equal?(UNDEFINED)
+          @hostname = force_utf8(Socket.gethostname)
+        end
+        @hostname
+      end
+
+      # Set the hostname to a specific value. If this is not specified, it will use the system hostname.
+      #
+      # @param hostname [String]
+      # @return [void]
+      def hostname=(hostname)
+        @hostname = force_utf8(hostname)
+      end
+
+      # Generate a global process ID that includes the hostname and process ID.
+      #
+      # @return [String] The global process ID.
+      def global_pid
+        if hostname
+          "#{hostname}-#{Process.pid}"
+        else
+          Process.pid.to_s
+        end
+      end
+
+      # Generate a global thread ID that includes the global process ID and the thread name.
+      #
+      # @return [String] The global thread ID.
+      def global_thread_id
+        "#{global_pid}-#{thread_name}"
+      end
+
+      # Get the name of a thread. The value will be based on the thread's name if it exists.
+      # Otherwise a unique id is generated based on the thread's object id. Only alphanumeric
+      # characters, underscores, dashes, and periods are kept in thread name.
+      #
+      # @param thread [Thread] The thread to get the name for. Defaults to the current thread.
+      # @return [String] The name of the thread.
+      def thread_name(thread = Thread.current)
+        thread.name ? slugify(thread.name) : thread.object_id.to_s(36)
+      end
+
+      # Force encode a string to UTF-8. Any invalid byte sequences will be
+      # ignored and replaced with an empty string.
+      #
+      # @param str [String] The string to encode.
+      # @return [String] The UTF-8 encoded string.
+      def force_utf8(str)
+        return nil if str.nil?
+
+        str.dup.force_encoding("ASCII-8BIT").encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
+      end
+
+      private
+
+      def slugify(str)
+        return nil if str.nil?
+
+        str = str.gsub(NON_SLUGGABLE_PATTERN, "-")
+        str.delete_prefix!("-")
+        str.chomp!("-")
+        str
+      end
+    end
+  end
+end

--- a/lib/lumberjack/utils.rb
+++ b/lib/lumberjack/utils.rb
@@ -15,7 +15,10 @@ module Lumberjack
     @hostname = UNDEFINED
 
     class << self
-      # Print warning when deprecated methods are called the first time.
+      # Print warning when deprecated methods are called the first time. This can be disabled
+      # by setting the environment variable `LUMBERJACK_NO_DEPRECATION_WARNINGS` to "true".
+      # You can see every usage of a deprecated method along with a full stack trace by setting
+      # the environment variable `VERBOSE_LUMBERJACK_DEPRECATION_WARNING` to "true".
       #
       # @param method [String] The name of the deprecated method.
       # @param message [String] Optional message to include in the warning.
@@ -26,9 +29,12 @@ module Lumberjack
           @deprecations_lock.synchronize do
             @deprecations ||= {}
             unless @deprecations.include?(method)
-              trace = caller_locations[2, 2].last
-              message = "DEPRECATION WARNING: #{message} Called from #{trace.path}:#{trace.lineno}."
-              @deprecations[method] = true
+              trace = caller[3..-1]
+              unless ENV["VERBOSE_LUMBERJACK_DEPRECATION_WARNING"] == "true"
+                trace = [trace.first]
+                @deprecations[method] = true
+              end
+              message = "DEPRECATION WARNING: #{message} Called from #{trace.join("\n")}"
               warn(message) unless ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"] == "true"
             end
           end

--- a/lib/lumberjack/utils.rb
+++ b/lib/lumberjack/utils.rb
@@ -94,6 +94,24 @@ module Lumberjack
         str.dup.force_encoding("ASCII-8BIT").encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
       end
 
+      # Flatten a tag hash to a single level hash with dot notation for nested keys.
+      #
+      # @param tag_hash [Hash] The hash to flatten.
+      # @return [Hash] The flattened hash.
+      def flatten_tags(tag_hash)
+        return {} unless tag_hash.is_a?(Hash)
+
+        tag_hash.each_with_object({}) do |(key, value), result|
+          if value.is_a?(Hash)
+            value.each do |sub_key, sub_value|
+              result["#{key}.#{sub_key}"] = sub_value
+            end
+          else
+            result[key] = value
+          end
+        end
+      end
+
       private
 
       def slugify(str)

--- a/spec/lumberjack/device/log_file_spec.rb
+++ b/spec/lumberjack/device/log_file_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Lumberjack::Device::LogFile do
     end
 
     device = Lumberjack::Device::LogFile.new(log_file, template: ":message")
-    device.write(Lumberjack::LogEntry.new(Time.now, 1, "New log entry", nil, $$, nil))
+    device.write(Lumberjack::LogEntry.new(Time.now, 1, "New log entry", nil, Process.pid, nil))
     device.close
 
     expect(File.read(log_file)).to eq("Existing contents\nNew log entry#{Lumberjack::LINE_SEPARATOR}")
@@ -31,11 +31,11 @@ RSpec.describe Lumberjack::Device::LogFile do
     device = Lumberjack::Device::LogFile.new(log_file, keep: 2, buffer_size: 32767)
 
     message = [0xC4, 0x90, 0xE1, 0xBB].pack("c*").force_encoding "ASCII-8BIT"
-    entry = Lumberjack::LogEntry.new(Time.now, 1, message, nil, $$, nil)
+    entry = Lumberjack::LogEntry.new(Time.now, 1, message, nil, Process.pid, nil)
     device.write entry
 
     message = "проверка"
-    entry = Lumberjack::LogEntry.new(Time.now, 1, message, nil, $$, nil)
+    entry = Lumberjack::LogEntry.new(Time.now, 1, message, nil, Process.pid, nil)
     device.write entry
 
     expect do
@@ -46,10 +46,10 @@ RSpec.describe Lumberjack::Device::LogFile do
   it "should reopen the file" do
     log_file = File.join(tmp_dir, "a#{rand(1000000000)}.log")
     device = Lumberjack::Device::LogFile.new(log_file, template: ":message")
-    device.write(Lumberjack::LogEntry.new(Time.now, 1, "message 1", nil, $$, nil))
+    device.write(Lumberjack::LogEntry.new(Time.now, 1, "message 1", nil, Process.pid, nil))
     device.close
     device.reopen
-    device.write(Lumberjack::LogEntry.new(Time.now, 1, "message 2", nil, $$, nil))
+    device.write(Lumberjack::LogEntry.new(Time.now, 1, "message 2", nil, Process.pid, nil))
     device.close
     expect(File.read(log_file)).to eq("message 1#{Lumberjack::LINE_SEPARATOR}message 2#{Lumberjack::LINE_SEPARATOR}")
   end

--- a/spec/lumberjack/device/null_spec.rb
+++ b/spec/lumberjack/device/null_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Lumberjack::Device::Null do
   it "should not generate any output" do
     device = Lumberjack::Device::Null.new
-    device.write(Lumberjack::LogEntry.new(Time.now, 1, "New log entry", nil, $$, nil))
+    device.write(Lumberjack::LogEntry.new(Time.now, 1, "New log entry", nil, Process.pid, nil))
     device.flush
     device.close
   end

--- a/spec/lumberjack/device/rolling_log_file_spec.rb
+++ b/spec/lumberjack/device/rolling_log_file_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Lumberjack::Device::RollingLogFile do
   before :all do
-    Lumberjack::Device::SizeRollingLogFile # needed by jruby
+    [Lumberjack::Device::SizeRollingLogFile] # needed by jruby
     create_tmp_dir
   end
 
@@ -14,7 +14,7 @@ RSpec.describe Lumberjack::Device::RollingLogFile do
     delete_tmp_files
   end
 
-  let(:entry) { Lumberjack::LogEntry.new(Time.now, 1, "New log entry", nil, $$, nil) }
+  let(:entry) { Lumberjack::LogEntry.new(Time.now, 1, "New log entry", nil, Process.pid, nil) }
 
   it "should check for rolling the log file on flush" do
     device = Lumberjack::Device::RollingLogFile.new(File.join(tmp_dir, "test.log"), buffer_size: 32767, min_roll_check: 0)
@@ -32,7 +32,7 @@ RSpec.describe Lumberjack::Device::RollingLogFile do
     allow(device).to receive_messages(archive_file_suffix: "rolled")
     device.write(entry)
     device.flush
-    device.write(Lumberjack::LogEntry.new(Time.now, 1, "Another log entry", nil, $$, nil))
+    device.write(Lumberjack::LogEntry.new(Time.now, 1, "Another log entry", nil, Process.pid, nil))
     device.close
     expect(File.read("#{log_file}.rolled")).to eq("New log entry#{Lumberjack::LINE_SEPARATOR}")
     expect(File.read(log_file)).to eq("Another log entry#{Lumberjack::LINE_SEPARATOR}")
@@ -46,7 +46,7 @@ RSpec.describe Lumberjack::Device::RollingLogFile do
     device.flush
     File.rename(log_file, "#{log_file}.rolled")
     device.flush
-    device.write(Lumberjack::LogEntry.new(Time.now, 1, "Another log entry", nil, $$, nil))
+    device.write(Lumberjack::LogEntry.new(Time.now, 1, "Another log entry", nil, Process.pid, nil))
     device.close
     expect(File.read("#{log_file}.rolled")).to eq("New log entry#{Lumberjack::LINE_SEPARATOR}")
     expect(File.read(log_file)).to eq("Another log entry#{Lumberjack::LINE_SEPARATOR}")
@@ -67,7 +67,7 @@ RSpec.describe Lumberjack::Device::RollingLogFile do
       thread_count.times do
         threads << Thread.new do
           entry_count.times do |i|
-            device.write(Lumberjack::LogEntry.new(Time.now, severity, message, "test", $$, nil))
+            device.write(Lumberjack::LogEntry.new(Time.now, severity, message, "test", Process.pid, nil))
             device.flush if i % 10 == 0
           end
           device.flush

--- a/spec/lumberjack/formatter/date_time_formatter_spec.rb
+++ b/spec/lumberjack/formatter/date_time_formatter_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe Lumberjack::Formatter::DateTimeFormatter do
 
   it "should not format a non date or time" do
     formatter = Lumberjack::Formatter::DateTimeFormatter.new("%Y-%m-%d %H:%M")
-    expect("foo").to eq "foo"
+    expect(formatter.call("foo")).to eq "foo"
   end
 
   it "should use iso8601 by default" do
     time = Time.now
     formatter = Lumberjack::Formatter::DateTimeFormatter.new
-    expect(formatter.call(time)).to eq time.iso8601
+    expect(formatter.call(time)).to eq time.iso8601(6)
   end
 end

--- a/spec/lumberjack/log_entry_spec.rb
+++ b/spec/lumberjack/log_entry_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Lumberjack::LogEntry do
     expect(entry.tags).to eq("unit_of_work_id" => "ABCD")
   end
 
-  it "should have a unit_of_work_id for backward compatibility with the 1.0 API" do
+  it "should have a unit_of_work_id for backward compatibility with the 1.0 API", suppress_warnings: true do
     entry = Lumberjack::LogEntry.new(Time.now, Logger::INFO, "test", "app", 1500, "ABCD")
     expect(entry.unit_of_work_id).to eq("ABCD")
     entry.unit_of_work_id = "1234"

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Lumberjack::Logger do
 
     it "should create a thread to flush the device" do
       expect(Thread).to receive(:new)
-      logger = Lumberjack::Logger.new(:null, flush_seconds: 10)
+      Lumberjack::Logger.new(:null, flush_seconds: 10)
     end
   end
 
@@ -317,21 +317,21 @@ RSpec.describe Lumberjack::Logger do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger.add(Logger::INFO, "test")
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO app(#{$$})] test")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO app(#{Process.pid})] test")
       end
 
       it "should add entries with a severity label" do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger.add(:info, "test")
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO app(#{$$})] test")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO app(#{Process.pid})] test")
       end
 
       it "should add entries with a custom progname and message" do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger.add(Logger::INFO, "test", "spec")
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{$$})] test")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{Process.pid})] test")
       end
 
       it "should add entries with a local progname and message" do
@@ -340,7 +340,7 @@ RSpec.describe Lumberjack::Logger do
         logger.set_progname("block") do
           logger.add(Logger::INFO, "test")
         end
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO block(#{$$})] test")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO block(#{Process.pid})] test")
       end
 
       it "should add entries with a progname but no message or block" do
@@ -349,28 +349,28 @@ RSpec.describe Lumberjack::Logger do
         logger.set_progname("default") do
           logger.add(Logger::INFO, nil, "message")
         end
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO default(#{$$})] message")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO default(#{Process.pid})] message")
       end
 
       it "should add entries with a block" do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger.add(Logger::INFO) { "test" }
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO app(#{$$})] test")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO app(#{Process.pid})] test")
       end
 
       it "should log entries (::Logger compatibility)" do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger.log(Logger::INFO, "test")
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO app(#{$$})] test")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO app(#{Process.pid})] test")
       end
 
       it "should append messages with unknown severity to the log" do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger << "test"
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 UNKNOWN app(#{$$})] test")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 UNKNOWN app(#{Process.pid})] test")
       end
     end
 
@@ -379,14 +379,14 @@ RSpec.describe Lumberjack::Logger do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger.add_entry(Logger::INFO, "test", "spec", "tag" => "ABCD")
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{$$})] test [tag:ABCD]")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{Process.pid})] test [tag:ABCD]")
       end
 
       it "should handle malformed tags" do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger.add_entry(Logger::INFO, "test", "spec", "ABCD")
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{$$})] test")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{Process.pid})] test")
       end
 
       it "should ouput entries to STDERR if they can't be written the the device" do
@@ -397,7 +397,7 @@ RSpec.describe Lumberjack::Logger do
           allow(Time).to receive_messages(now: time)
           expect(device).to receive(:write).and_raise(StandardError.new("Cannot write to device"))
           logger.add_entry(Logger::INFO, "test")
-          expect($stderr.string).to include("[2011-01-30T12:31:56.123 INFO app(#{$$})] test")
+          expect($stderr.string).to include("[2011-01-30T12:31:56.123 INFO app(#{Process.pid})] test")
           expect($stderr.string).to include("StandardError: Cannot write to device")
         ensure
           $stderr = stderr
@@ -408,7 +408,7 @@ RSpec.describe Lumberjack::Logger do
         time = Time.parse("2011-01-30T12:31:56.123")
         allow(Time).to receive_messages(now: time)
         logger.add_entry(Logger::INFO, "test", "spec", tag: lambda { "foo" })
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{$$})] test [tag:foo]")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{Process.pid})] test [tag:foo]")
       end
 
       it "should not get into infinite loops by logging entries while logging entries" do
@@ -419,7 +419,7 @@ RSpec.describe Lumberjack::Logger do
           "foo"
         end
         logger.add_entry(Logger::INFO, "test", "spec", tag: tag_proc)
-        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{$$})] test [tag:foo]")
+        expect(output.string.chomp).to eq("[2011-01-30T12:31:56.123 INFO spec(#{Process.pid})] test [tag:foo]")
       end
     end
 
@@ -455,42 +455,42 @@ RSpec.describe Lumberjack::Logger do
 
         it "should log a message string" do
           logger.send(level, "test")
-          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} app(#{$$})] test")
+          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} app(#{Process.pid})] test")
         end
 
         it "should log a message string with a progname" do
           logger.send(level, "test", "spec")
-          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} spec(#{$$})] test")
+          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} spec(#{Process.pid})] test")
         end
 
         it "should log a message string with tags" do
           logger.send(level, "test", tag: 1)
-          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} app(#{$$})] test [tag:1]")
+          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} app(#{Process.pid})] test [tag:1]")
         end
 
         it "should log a message block" do
           logger.send(level) { "test" }
-          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} app(#{$$})] test")
+          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} app(#{Process.pid})] test")
         end
 
         it "should log a message block with a progname" do
           logger.send(level, "spec") { "test" }
-          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} spec(#{$$})] test")
+          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} spec(#{Process.pid})] test")
         end
 
         it "should log a message block with tags" do
           logger.send(level, tag: 1) { "test" }
-          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} app(#{$$})] test [tag:1]")
+          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} app(#{Process.pid})] test [tag:1]")
         end
 
         it "should log a message block with a progname and tags" do
           logger.send(level, "spec", tag: 1) { "test" }
-          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} spec(#{$$})] test [tag:1]")
+          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} spec(#{Process.pid})] test [tag:1]")
         end
 
         it "should log a message block with a progname and tags" do
           logger.send(level, {tag: 1}, "spec") { "test" }
-          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} spec(#{$$})] test [tag:1]")
+          expect(output.string.chomp).to eq("[#{timestamp} #{level.upcase} spec(#{Process.pid})] test [tag:1]")
         end
       end
     end
@@ -521,6 +521,24 @@ RSpec.describe Lumberjack::Logger do
 
     describe "tags" do
       let(:device) { Lumberjack::Device::Writer.new(output, buffer_size: 0, template: ":message - :count - :tags") }
+
+      it "should be able to add global tags to the logger" do
+        logger.tag_globally(count: 1, foo: "bar")
+        logger.info("one")
+        logger.info("two", count: 2)
+        lines = output.string.split(n)
+        expect(lines[0]).to eq "one - 1 - [foo:bar]"
+        expect(lines[1]).to eq "two - 2 - [foo:bar]"
+      end
+
+      it "should be able to add global tags with the tag method and no block or context", suppress_warnings: true do
+        logger.tag(foo: "bar", count: 1)
+        logger.info("one")
+        logger.info("two", count: 2)
+        lines = output.string.split(n)
+        expect(lines[0]).to eq "one - 1 - [foo:bar]"
+        expect(lines[1]).to eq "two - 2 - [foo:bar]"
+      end
 
       it "should be able to add tags to the logs" do
         logger.level = :debug
@@ -567,7 +585,7 @@ RSpec.describe Lumberjack::Logger do
       end
 
       it "should add and remove tags in the global scope if there is no block" do
-        logger.tag(count: 1, foo: "bar")
+        logger.tag_globally(count: 1, foo: "bar")
         logger.info("one")
         logger.remove_tag(:foo)
         logger.info("two")
@@ -595,7 +613,7 @@ RSpec.describe Lumberjack::Logger do
       end
 
       it "should work with a frozen hash" do
-        logger.tag({foo: "bar"}.freeze)
+        logger.tag_globally({foo: "bar"}.freeze)
         logger.tag(other: 1) do
           expect(logger.tags).to eq("foo" => "bar", "other" => 1)
         end
@@ -620,7 +638,7 @@ RSpec.describe Lumberjack::Logger do
       end
 
       it "should remove global tags from the logger" do
-        logger.tag(foo: "bar")
+        logger.tag_globally(foo: "bar")
         begin
           expect(logger.tags).to eq({"foo" => "bar"})
           logger.untagged do
@@ -643,7 +661,7 @@ RSpec.describe Lumberjack::Logger do
       end
 
       it "should allow adding tags inside the block" do
-        logger.tag(foo: "bar") do
+        logger.tag_globally(foo: "bar") do
           expect(logger.tags).to eq({"foo" => "bar"})
           logger.untagged do
             logger.tag(stuff: "other") do

--- a/spec/lumberjack/rack/request_id_spec.rb
+++ b/spec/lumberjack/rack/request_id_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe Lumberjack::Rack::RequestId do
+RSpec.describe Lumberjack::Rack::RequestId, suppress_warnings: true do
   it "should use the action dispatch request id if it exists" do
     app = lambda { |env| [200, {"Content-Type" => env["Content-Type"], "Unit-Of-Work" => Lumberjack.unit_of_work_id.to_s}, ["OK"]] }
     handler = Lumberjack::Rack::RequestId.new(app)

--- a/spec/lumberjack/rack/unit_of_work_spec.rb
+++ b/spec/lumberjack/rack/unit_of_work_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe Lumberjack::Rack::UnitOfWork do
+RSpec.describe Lumberjack::Rack::UnitOfWork, suppress_warnings: true do
   it "should create a unit of work in a middleware stack" do
     app = lambda { |env| [200, {"Content-Type" => env["Content-Type"], "Unit-Of-Work" => Lumberjack.unit_of_work_id.to_s}, ["OK"]] }
     handler = Lumberjack::Rack::UnitOfWork.new(app)

--- a/spec/lumberjack/tagged_logger_support_spec.rb
+++ b/spec/lumberjack/tagged_logger_support_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe Lumberjack::TaggedLoggerSupport do
 
   describe "logger" do
     describe "tagged" do
+      it "should add global tags to the logger with no block" do
+        logger.tagged("foo", "bar")
+        logger.info("message", count: 1)
+        line = output.string.chomp
+        expect(line).to eq 'message - 1 - [tagged:["foo", "bar"]]'
+      end
+
       it "should add tags to the tag 'tagged'" do
         logger.tagged("foo", "bar") do
           logger.info("message", count: 1)

--- a/spec/lumberjack/utils_spec.rb
+++ b/spec/lumberjack/utils_spec.rb
@@ -63,4 +63,27 @@ describe Lumberjack::Utils do
       expect(Lumberjack::Utils.flatten_tags("not a hash")).to eq({})
     end
   end
+
+  describe ".deprecated" do
+    around do |example|
+      original_value = ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"]
+      begin
+        ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"] = "false"
+        example.run
+      ensure
+        ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"] = original_value
+      end
+    end
+
+    it "prints a deprecation warning the first time a deprecated method is called" do
+      retval = nil
+      expect { retval = Lumberjack::Utils.deprecated("test_method_1", "This is deprecated") { :foo } }.to output.to_stderr
+      expect(retval).to eq :foo
+    end
+
+    it "does not print the warning again for subsequent calls" do
+      expect { Lumberjack::Utils.deprecated("test_method_2", "This is deprecated") { :foo } }.to output(/DEPRECATION WARNING: This is deprecated/).to_stderr
+      expect { Lumberjack::Utils.deprecated("test_method_2", "This is deprecated") { :bar } }.not_to output.to_stderr
+    end
+  end
 end

--- a/spec/lumberjack/utils_spec.rb
+++ b/spec/lumberjack/utils_spec.rb
@@ -51,7 +51,7 @@ describe Lumberjack::Utils do
 
   describe ".flatten_tags" do
     it "flattens a nested tag hash" do
-      tag_hash = { "user" => { "id" => 123, "name" => "Alice" }, "action" => "login" }
+      tag_hash = {"user" => {"id" => 123, "name" => "Alice"}, "action" => "login"}
       expect(Lumberjack::Utils.flatten_tags(tag_hash)).to eq(
         "user.id" => 123,
         "user.name" => "Alice",

--- a/spec/lumberjack/utils_spec.rb
+++ b/spec/lumberjack/utils_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Lumberjack::Utils do
+  describe ".hostname" do
+    it "returns the hostname in UTF-8 encoding" do
+      expect(Lumberjack::Utils.hostname).to be_a(String)
+      expect(Lumberjack::Utils.hostname.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "caches the hostname" do
+      expect(Lumberjack::Utils.hostname.object_id).to eq(Lumberjack::Utils.hostname.object_id)
+    end
+
+    it "returns an explicitly set hostname" do
+      hostname = Lumberjack::Utils.hostname
+      begin
+        Lumberjack::Utils.hostname = "test-host"
+        expect(Lumberjack::Utils.hostname).to eq("test-host")
+      ensure
+        Lumberjack::Utils.hostname = hostname
+      end
+    end
+  end
+
+  describe ".global_pid" do
+    it "generates a global process ID" do
+      expect(Lumberjack::Utils.global_pid).to eq "#{Lumberjack::Utils.hostname}-#{Process.pid}"
+    end
+  end
+
+  describe ".global_thread_id" do
+    it "generates a global thread ID" do
+      expect(Lumberjack::Utils.global_thread_id).to eq "#{Lumberjack::Utils.global_pid}-#{Lumberjack::Utils.thread_name}"
+    end
+  end
+
+  describe ".thread_name" do
+    it "generates a name based on the object id if there is no thread name" do
+      thread = Thread.new { sleep 0.001 }
+      expect(Lumberjack::Utils.thread_name(thread)).to eq thread.object_id.to_s(36)
+    end
+
+    it "generates a sluggified name based on the thread name" do
+      thread = Thread.new { sleep 0.001 }
+      thread.name = "Test Thread"
+      expect(Lumberjack::Utils.thread_name(thread)).to eq "Test-Thread"
+    end
+  end
+end

--- a/spec/lumberjack/utils_spec.rb
+++ b/spec/lumberjack/utils_spec.rb
@@ -48,4 +48,19 @@ describe Lumberjack::Utils do
       expect(Lumberjack::Utils.thread_name(thread)).to eq "Test-Thread"
     end
   end
+
+  describe ".flatten_tags" do
+    it "flattens a nested tag hash" do
+      tag_hash = { "user" => { "id" => 123, "name" => "Alice" }, "action" => "login" }
+      expect(Lumberjack::Utils.flatten_tags(tag_hash)).to eq(
+        "user.id" => 123,
+        "user.name" => "Alice",
+        "action" => "login"
+      )
+    end
+
+    it "returns an empty hash for non-hash input" do
+      expect(Lumberjack::Utils.flatten_tags("not a hash")).to eq({})
+    end
+  end
 end

--- a/spec/lumberjack_spec.rb
+++ b/spec/lumberjack_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Lumberjack do
   end
 
   describe "unit of work" do
-    it "should create a unit work with a unique id in a block in a tag" do
+    it "should create a unit work with a unique id in a block in a tag", suppress_warnings: true do
       expect(Lumberjack.unit_of_work_id).to eq(nil)
       Lumberjack.unit_of_work do
         id_1 = Lumberjack.unit_of_work_id
@@ -87,7 +87,7 @@ RSpec.describe Lumberjack do
       expect(Lumberjack.context[:unit_of_work_id]).to eq nil
     end
 
-    it "should allow you to specify a unit of work id for a block" do
+    it "should allow you to specify a unit of work id for a block", suppress_warnings: true do
       Lumberjack.unit_of_work("foo") do
         expect(Lumberjack.unit_of_work_id).to eq("foo")
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ begin
 rescue LoadError
 end
 
-require_relative "../lib/lumberjack.rb"
+require_relative "../lib/lumberjack"
 
 RSpec.configure do |config|
   config.warnings = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ begin
 rescue LoadError
 end
 
-require File.expand_path("../../lib/lumberjack.rb", __FILE__)
+require_relative "../lib/lumberjack.rb"
 
 RSpec.configure do |config|
   config.warnings = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,16 @@ require File.expand_path("../../lib/lumberjack.rb", __FILE__)
 RSpec.configure do |config|
   config.warnings = true
   config.order = :random
+
+  config.around(:each, :suppress_warnings) do |example|
+    save_val = ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"]
+    ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"] = "true"
+    begin
+      example.run
+    ensure
+      ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"] = save_val
+    end
+  end
 end
 
 def tmp_dir


### PR DESCRIPTION
### Added

- Added helper methods to generate global PID's and thread ids.
- Added `Lumberjack::Logger#tag_globally` to explicitly set a global tag for all loggers.
- Added `Lumberjack::Utils.hostname` to get the hostname in UTF-8 encoding.
- Added `Lumberjack::Utils.global_pid` to get a global process id in a consistent format.
- Added `Lumberjack::Utils.global_thread_id` to get a thread id in a consistent format.
- Added `Lumberjack::Utils.thread_name` to get a thread name in a consistent format.

### Changed

- Default date/time format for log entries is now ISO-8601 with microsecond precision.
