### PR TITLE
Remove support for setting global tags with tag method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed deprecated unit of work id code. These have been replaced with tags.
+- Removed deprecated support for setting global tags with `Lumberjack::Logger#tag`. Now calling `tag` outside of a block or context will be ignored. Use `tag_globally` to set global tags.
 
 ## 1.4.0
 

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -502,11 +502,8 @@ module Lumberjack
     # for the duration of the block. Otherwise the tags will be applied on the current
     # logger context for the duration of that context.
     #
-    # If there is no block or context, the tags will be applied to the global context.
-    # This behavior is deprecated. Use the `tag_globally` method to set global tags instead.
-    #
     # @param [Hash] tags The tags to set.
-    # @return [void]
+    # @return [Object, nil] The result of the block if given, otherwise nil.
     def tag(tags, &block)
       thread_tags = thread_local_value(:lumberjack_logger_tags)
       if block
@@ -515,11 +512,6 @@ module Lumberjack
         push_thread_local_value(:lumberjack_logger_tags, merged_tags, &block)
       elsif thread_tags
         TagContext.new(thread_tags).tag(tags)
-        nil
-      else
-        Utils.deprecated("Lumberjack::Logger#tag", "Lumberjack::Logger#tag must be called with a block or inside a context block. In version 2.0 it will no longer be used for setting global tags. Use Lumberjack::Logger#tag_globally instead.") do
-          tag_globally(tags)
-        end
       end
     end
 

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -567,13 +567,11 @@ RSpec.describe Lumberjack::Logger do
         expect(lines[1]).to eq "two - 2 - [foo:bar]"
       end
 
-      it "should be able to add global tags with the tag method and no block or context", suppress_warnings: true do
-        logger.tag(foo: "bar", count: 1)
+      it "ignores tags added outside of a block or tag context" do
+        logger.tag(foo: "bar")
         logger.info("one")
-        logger.info("two", count: 2)
         lines = output.string.split(n)
-        expect(lines[0]).to eq "one - 1 - [foo:bar]"
-        expect(lines[1]).to eq "two - 2 - [foo:bar]"
+        expect(lines[0]).to eq "one -  -"
       end
 
       it "should be able to add tags to the logs" do


### PR DESCRIPTION
- Removed deprecated support for setting global tags with `Lumberjack::Logger#tag`. Now calling `tag` outside of a block or context will be ignored. Use `tag_globally` to set global tags.
