### PR TITLE
Update formatters and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added IO compatibility methods for logging. Calling `logger.write`, `logger.puts`, `logger.print`, or `logger.printf` will write log messages with a severity level of UNKNOWN.
 - Added `Lumberjack::Device::Test` class for use in testing logging functionality. This device will buffer log entries and has `match?` and `include?` methods that can be used for assertions in tests.
 - Added support for standard library `Logger::Formatter`. This is for compatibility with the standard library `Logger`. If a standard library logger is passed to `Lumberjack::Logger` as the formatter, it will override the template when writing to a stream. Tags are not available in the output when using a standard library formatter.
+- Classes can now define their own formatting in logs by implementing the `to_log_format` method. If an object responds to this method, it will be called in lieu of looking up the formatter by class. This allows a pattern of defining log formatting along with the code rather than in a an initializer.
+- Tag formatters can now add class formatters by class name using the `add_class` method. This allows setting a class formatter before the class has been loaded.
+- A tag format can now be passed to the `Lumberjack::Template` class to specify how to format tag name/value pairs. The default is "[%s:%s]".
 
 ### Changed
 

--- a/lib/lumberjack/entry_formatter.rb
+++ b/lib/lumberjack/entry_formatter.rb
@@ -79,7 +79,11 @@ module Lumberjack
     # @return [Array<Object, Hash>] The formatted message and tags.
     def format(message, tags)
       message = message.call if message.is_a?(Proc)
-      message = message_formatter.format(message) if message_formatter
+      if message.respond_to?(:to_log_format, true) && message.method(:to_log_format).arity == 0
+        message = message.to_log_format
+      elsif message_formatter
+        message = message_formatter.format(message)
+      end
 
       message_tags = nil
       if message.is_a?(Formatter::TaggedMessage)

--- a/lib/lumberjack/entry_formatter.rb
+++ b/lib/lumberjack/entry_formatter.rb
@@ -79,7 +79,7 @@ module Lumberjack
     # @return [Array<Object, Hash>] The formatted message and tags.
     def format(message, tags)
       message = message.call if message.is_a?(Proc)
-      if message.respond_to?(:to_log_format, true) && message.method(:to_log_format).arity == 0
+      if message.respond_to?(:to_log_format, true) && message.method(:to_log_format).parameters.empty?
         message = message.to_log_format
       elsif message_formatter
         message = message_formatter.format(message)

--- a/lib/lumberjack/formatter.rb
+++ b/lib/lumberjack/formatter.rb
@@ -40,8 +40,11 @@ module Lumberjack
 
     def initialize
       @class_formatters = {}
+      @has_string_formatter = false
+      @has_numeric_formatter = false
+      @has_boolean_formatter = false
+
       structured_formatter = StructuredFormatter.new(self)
-      add([String, Numeric, TrueClass, FalseClass], :object)
       add(Object, InspectFormatter.new)
       add(Exception, :exception)
       add(Enumerable, structured_formatter)
@@ -116,6 +119,9 @@ module Lumberjack
           @class_formatters[k.to_s] = formatter
         end
       end
+
+      set_optimized_flags!
+
       self
     end
 
@@ -133,6 +139,9 @@ module Lumberjack
       Array(klass).each do |k|
         @class_formatters.delete(k.to_s)
       end
+
+      set_optimized_flags!
+
       self
     end
 
@@ -141,6 +150,8 @@ module Lumberjack
     # @return [self] Returns itself so that clear statements can be chained together.
     def clear
       @class_formatters.clear
+      set_optimized_flags!
+
       self
     end
 
@@ -156,6 +167,12 @@ module Lumberjack
     # @param message [Object] The message object to format.
     # @return [Object] The formatted object.
     def format(message)
+      # These primitive types are the most common in logs and so are optimized here
+      # for the normal case where a custom formatter has not been defined.
+      return message if !@has_string_formatter && message.is_a?(String)
+      return message if !@has_numeric_formatter && (message.is_a?(Integer) || message.is_a?(Float) || (defined?(BigDecimal) && message.is_a?(BigDecimal)))
+      return message if !@has_boolean_formatter && (message == true || message == false)
+
       formatter = formatter_for(message.class)
       if formatter&.respond_to?(:call)
         formatter.call(message)
@@ -186,6 +203,12 @@ module Lumberjack
       formatter = nil
       klass.ancestors.detect { |ancestor| formatter = @class_formatters[ancestor.name] }
       formatter
+    end
+
+    def set_optimized_flags!
+      @has_string_formatter = @class_formatters.include?("String")
+      @has_numeric_formatter = @class_formatters.slice("Integer", "Float", "BigDecimal", "Numeric").any?
+      @has_boolean_formatter = @class_formatters.include?("TrueClass") || @class_formatters.include?("FalseClass")
     end
   end
 end

--- a/lib/lumberjack/formatter.rb
+++ b/lib/lumberjack/formatter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bigdecimal"
 module Lumberjack
   # This class controls the conversion of log entry messages into a loggable format. This allows you
   # to log any object you want and have the logging system deal with converting it into a string.
@@ -169,9 +170,14 @@ module Lumberjack
     def format(message)
       # These primitive types are the most common in logs and so are optimized here
       # for the normal case where a custom formatter has not been defined.
-      return message if !@has_string_formatter && message.is_a?(String)
-      return message if !@has_numeric_formatter && (message.is_a?(Integer) || message.is_a?(Float) || (defined?(BigDecimal) && message.is_a?(BigDecimal)))
-      return message if !@has_boolean_formatter && (message == true || message == false)
+      case message
+      when String
+        return message unless @has_string_formatter
+      when Integer, Float, BigDecimal
+        return message unless @has_numeric_formatter
+      when true, false
+        return message unless @has_boolean_formatter
+      end
 
       formatter = formatter_for(message.class)
       if formatter&.respond_to?(:call)

--- a/lib/lumberjack/formatter.rb
+++ b/lib/lumberjack/formatter.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bigdecimal"
 module Lumberjack
   # This class controls the conversion of log entry messages into a loggable format. This allows you
   # to log any object you want and have the logging system deal with converting it into a string.
@@ -173,8 +172,12 @@ module Lumberjack
       case message
       when String
         return message unless @has_string_formatter
-      when Integer, Float, BigDecimal
+      when Integer, Float
         return message unless @has_numeric_formatter
+      when Numeric
+        if defined?(BigDecimal) && message.is_a?(BigDecimal)
+          return message unless @has_numeric_formatter
+        end
       when true, false
         return message unless @has_boolean_formatter
       end

--- a/spec/lumberjack/entry_formatter_spec.rb
+++ b/spec/lumberjack/entry_formatter_spec.rb
@@ -72,6 +72,20 @@ describe Lumberjack::EntryFormatter do
       expect(tags).to eq({"tag" => "foobar", "foo" => "bar"})
     end
 
+    it "applies the to_log_format method instead of the registered formatter if it exists" do
+      obj = +"FooBar"
+      def obj.to_log_format
+        "Custom format for #{self}"
+      end
+
+      entry_formatter.add(String) { |s| "String: #{s}" }
+      message, _ = entry_formatter.format("foobar", {})
+      expect(message).to eq("String: foobar")
+
+      message, _ = entry_formatter.format(obj, {})
+      expect(message).to eq("Custom format for FooBar")
+    end
+
     it "applies the tag formatter to the tags" do
       entry_formatter.tags { add("foo") { |obj| "Foo: #{obj}" } }
       message, tags = entry_formatter.format("foobar", {"foo" => "bar"})

--- a/spec/lumberjack/formatter_spec.rb
+++ b/spec/lumberjack/formatter_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe Lumberjack::Formatter do
   describe "optimized formatters for primative types" do
     let(:formatter) { Lumberjack::Formatter.empty.add(Object, :inspect) }
 
-    it "should have an optimized set of formatters that return self for primative types" do
+  describe "optimized formatters for primitive types" do
+    let(:formatter) { Lumberjack::Formatter.empty.add(Object, :inspect) }
+
+    it "should have an optimized set of formatters that return self for primitive types" do
       expect(formatter.format("foo")).to eq("foo")
       expect(formatter.format(1)).to eq(1)
       expect(formatter.format(2.1)).to eq(2.1)

--- a/spec/lumberjack/formatter_spec.rb
+++ b/spec/lumberjack/formatter_spec.rb
@@ -5,6 +5,22 @@ require "spec_helper"
 RSpec.describe Lumberjack::Formatter do
   let(:formatter) { Lumberjack::Formatter.new }
 
+  describe "optimized formatters for primative types" do
+    let(:formatter) { Lumberjack::Formatter.empty.add(Object, :inspect) }
+
+    it "should have an optimized set of formatters that return self for primative types" do
+      expect(formatter.format("foo")).to eq("foo")
+      expect(formatter.format(1)).to eq(1)
+      expect(formatter.format(2.1)).to eq(2.1)
+      expect(formatter.format(true)).to eq(true)
+      expect(formatter.format(false)).to eq(false)
+      expect(formatter.format(:foo)).to eq(":foo")
+    end
+
+    it "should be able to override the optimized formatters" do
+    end
+  end
+
   it "should have a default set of formatters" do
     expect(formatter.format("abc")).to eq("abc")
     expect(formatter.format([1, 2, 3])).to eq([1, 2, 3])
@@ -43,18 +59,29 @@ RSpec.describe Lumberjack::Formatter do
   end
 
   it "should be able to remove a formatter for a class" do
-    formatter.remove(String)
-    expect(formatter.format("abc")).to eq("\"abc\"")
+    formatter = Lumberjack::Formatter.empty
+    formatter.add(Symbol, :inspect)
+    expect(formatter.format(:foo)).to eq(":foo")
+    formatter.remove(Symbol)
+    expect(formatter.format(:foo)).to eq(:foo)
   end
 
   it "should be able to remove a formatter for a class" do
-    formatter.remove("String")
-    expect(formatter.format("abc")).to eq("\"abc\"")
+    formatter = Lumberjack::Formatter.empty
+    formatter.add([Symbol, Array], :inspect)
+    expect(formatter.format(:foo)).to eq(":foo")
+    formatter.remove([Symbol, Array])
+    expect(formatter.format(:foo)).to eq(:foo)
   end
 
   it "should be able to remove multiple formatters" do
-    formatter.remove([String, Numeric])
-    expect(formatter.format("abc")).to eq("\"abc\"")
+    formatter = Lumberjack::Formatter.empty
+    formatter.add([Symbol, Array], :inspect)
+    expect(formatter.format(:foo)).to eq(":foo")
+    expect(formatter.format([1, 2, 3])).to eq([1, 2, 3].inspect)
+    formatter.remove([Symbol, Array])
+    expect(formatter.format(:foo)).to eq(:foo)
+    expect(formatter.format([1, 2, 3])).to eq([1, 2, 3])
   end
 
   it "should be able to chain add and remove calls" do

--- a/spec/lumberjack/tag_formatter_spec.rb
+++ b/spec/lumberjack/tag_formatter_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe Lumberjack::TagFormatter do
     expect(tag_formatter.format(tags)).to eq({"foo" => '"bar"', "baz" => "boo!", "count" => "1!"})
   end
 
+  it "should be able to add tag formatters with add_tag" do
+    tag_formatter = Lumberjack::TagFormatter.new
+    tag_formatter.add_tag("foo") { |val| {"bar" => val.to_s} }
+    expect(tag_formatter.format({"foo" => 12})).to eq({"foo" => {"bar" => "12"}})
+  end
+
   it "should be able to add class formatters" do
     tag_formatter = Lumberjack::TagFormatter.new.add(Integer) { |val| val * 2 }
     tag_formatter.add(String, :redact)
@@ -35,6 +41,12 @@ RSpec.describe Lumberjack::TagFormatter do
 
     tag_formatter.remove(String)
     expect(tag_formatter.format(tags)).to eq({"foo" => "bar", "baz" => "boo", "count" => 2})
+  end
+
+  it "should be able to add class formatters by class name" do
+    tag_formatter = Lumberjack::TagFormatter.new
+    tag_formatter.add_class("String") { |val| val.reverse }
+    expect(tag_formatter.format({"foo" => "bar", "baz" => "boo", "count" => 1})).to eq({"foo" => "rab", "baz" => "oob", "count" => 1})
   end
 
   it "should use a class formatter on child classes" do

--- a/spec/lumberjack/template_spec.rb
+++ b/spec/lumberjack/template_spec.rb
@@ -10,29 +10,29 @@ RSpec.describe Lumberjack::Template do
   describe "format" do
     it "should format a log entry with a template string" do
       template = Lumberjack::Template.new(":message - :severity, :time, :progname@:pid (:unit_of_work_id) :tags")
-      expect(template.call(entry)).to eq("line 1 - INFO, 2011-01-15T14:23:45.123, app@12345 (ABCD) [foo:bar]#{Lumberjack::LINE_SEPARATOR}line 2#{Lumberjack::LINE_SEPARATOR}line 3")
+      expect(template.call(entry)).to eq("line 1 - INFO, 2011-01-15T14:23:45.123, app@12345 (ABCD) [foo:bar]#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should be able to specify a template for additional lines in a message" do
       template = Lumberjack::Template.new(":message (:time)", additional_lines: " // :message")
-      expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123) // line 2 // line 3")
+      expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123) // line 2 // line 3#{Lumberjack::LINE_SEPARATOR}")
     end
   end
 
   describe "timestamp format" do
     it "should be able to specify the time format for log entries as microseconds" do
       template = Lumberjack::Template.new(":message (:time)", time_format: :microseconds)
-      expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123000)#{Lumberjack::LINE_SEPARATOR}line 2#{Lumberjack::LINE_SEPARATOR}line 3")
+      expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123000)#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should be able to specify the time format for log entries as milliseconds" do
       template = Lumberjack::Template.new(":message (:time)", time_format: :milliseconds)
-      expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123)#{Lumberjack::LINE_SEPARATOR}line 2#{Lumberjack::LINE_SEPARATOR}line 3")
+      expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123)#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should be able to specify the time format for log entries with a custom format" do
       template = Lumberjack::Template.new(":message (:time)", time_format: "%m/%d/%Y, %I:%M:%S %p")
-      expect(template.call(entry)).to eq("line 1 (01/15/2011, 02:23:45 PM)#{Lumberjack::LINE_SEPARATOR}line 2#{Lumberjack::LINE_SEPARATOR}line 3")
+      expect(template.call(entry)).to eq("line 1 (01/15/2011, 02:23:45 PM)#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
   end
 
@@ -40,25 +40,31 @@ RSpec.describe Lumberjack::Template do
     it "should format named tags in the template and not in the :tags placement" do
       template = Lumberjack::Template.new(":message - :foo - :tags")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo" => "bar", "tag" => "a")
-      expect(template.call(entry)).to eq("here - bar - [tag:a]")
+      expect(template.call(entry)).to eq("here - bar - [tag:a]#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should put nothing in place of missing named tags" do
       template = Lumberjack::Template.new(":message - :foo - :tags")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "tag" => "a")
-      expect(template.call(entry)).to eq("here -  - [tag:a]")
+      expect(template.call(entry)).to eq("here -  - [tag:a]#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should remove line separators in tags" do
       template = Lumberjack::Template.new(":message - :foo - :tags")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "tag" => "a#{Lumberjack::LINE_SEPARATOR}b")
-      expect(template.call(entry)).to eq("here -  - [tag:a b]")
+      expect(template.call(entry)).to eq("here -  - [tag:a b]#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should handle tags with special characters by surrounding with brackets" do
       template = Lumberjack::Template.new(":message - :{foo.bar} - :{@baz!} - :tags")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo.bar" => "test", "@baz!" => 1, "tag" => "a")
-      expect(template.call(entry)).to eq("here - test - 1 - [tag:a]")
+      expect(template.call(entry)).to eq("here - test - 1 - [tag:a]#{Lumberjack::LINE_SEPARATOR}")
+    end
+
+    it "can customize the tag format" do
+      template = Lumberjack::Template.new(":message - :foo - :tags", tag_format: "(%s=%s)")
+      entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo" => "bar", "tag" => "a")
+      expect(template.call(entry)).to eq("here - bar - (tag=a)#{Lumberjack::LINE_SEPARATOR}")
     end
   end
 end


### PR DESCRIPTION
- Classes can now define their own formatting in logs by implementing the `to_log_format` method. If an object responds to this method, it will be called in lieu of looking up the formatter by class. This allows a pattern of defining log formatting along with the code rather than in a an initializer.
- Tag formatters can now add class formatters by class name using the `add_class` method. This allows setting a class formatter before the class has been loaded.
- A tag format can now be passed to the `Lumberjack::Template` class to specify how to format tag name/value pairs. The default is "[%s:%s]".
