### PR TITLE
Remove internal buffer in the Writer device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed deprecated unit of work id code. These have been replaced with tags.
 - Removed deprecated support for setting global tags with `Lumberjack::Logger#tag`. Now calling `tag` outside of a block or context will be ignored. Use `tag!` to set default tags on a logger.
 - Removed the devices that handled logging to files (`Lumberjack::Device::LogFile`, `Lumberjack::Device::RollingLogFile`, `Lumberjack::Device::DateRollingLogFile`, and `Lumberjack::Device::SizeRollingLogFile`) since file logging is now handled by the standard library `Logger::LogDevice` class.
+- Removed internal buffer from the `Lumberjack::Device::Writer` class. This funcationality was more useful in the days of slower I/O operations when logs were written to spinning hard disks. The functionality is no longer as useful and is not worth the overhead. The `Lumberjack::Logger.last_flushed_at` method has also been removed.
 - Removed support for Ruby versions < 2.5.
 
 ## 1.4.0

--- a/lib/lumberjack/device/writer.rb
+++ b/lib/lumberjack/device/writer.rb
@@ -2,57 +2,11 @@
 
 module Lumberjack
   class Device
-    # This logging device writes log entries as strings to an IO stream. By default, messages will be buffered
-    # and written to the stream in a batch when the buffer is full or when +flush+ is called.
-    #
-    # Subclasses can implement a +before_flush+ method if they have logic to execute before flushing the log.
-    # If it is implemented, it will be called before every flush inside a mutex lock.
+    # This logging device writes log entries as strings to an IO stream. Output is written as a string
+    # formatted by the template passed in.
     class Writer < Device
       DEFAULT_FIRST_LINE_TEMPLATE = "[:time :severity :progname(:pid)] :message :tags"
       DEFAULT_ADDITIONAL_LINES_TEMPLATE = "#{Lumberjack::LINE_SEPARATOR}> :message"
-
-      # The size of the internal buffer. Defaults to 32K.
-      attr_reader :buffer_size
-
-      # Internal buffer to batch writes to the stream.
-      class Buffer # :nodoc:
-        attr_reader :size
-
-        def initialize
-          @values = []
-          @size = 0
-          @lock = Mutex.new
-        end
-
-        def <<(string)
-          @lock.synchronize do
-            @values << string
-            @size += string.length
-          end
-        end
-
-        def empty?
-          @values.empty?
-        end
-
-        def pop!(&before_flush)
-          return nil if @values.empty?
-
-          popped = nil
-          @lock.synchronize do
-            before_flush&.call
-            popped = @values
-            clear
-          end
-
-          popped
-        end
-
-        def clear
-          @values = []
-          @size = 0
-        end
-      end
 
       # Create a new device to write log entries to a stream. Entries are converted to strings
       # using a Template. The template can be specified using the :template option. This can
@@ -67,16 +21,11 @@ module Lumberjack
       # The default template is "[:time :severity :progname(:pid)] :message"
       # with additional lines formatted as "\n  :message".
       #
-      # The size of the internal buffer in bytes can be set by providing :buffer_size (defaults to 32K).
-      #
       # @param [IO] stream The stream to write log entries to.
       # @param [Hash] options The options for the device.
       def initialize(stream, options = {})
         @stream = stream
         @stream.sync = true if @stream.respond_to?(:sync=)
-
-        @buffer = Buffer.new
-        @buffer_size = options[:buffer_size] || 0
 
         @binmode = options[:binmode]
 
@@ -91,16 +40,6 @@ module Lumberjack
             @template = Template.new(template, additional_lines: additional_lines, time_format: options[:time_format])
           end
         end
-      end
-
-      # Set the buffer size in bytes. The device will only be physically written to when the buffer size
-      # is exceeded.
-      #
-      # @param [Integer] value The size of the buffer in bytes.
-      # @return [void]
-      def buffer_size=(value)
-        @buffer_size = value
-        flush
       end
 
       # Write an entry to the stream. The entry will be converted into a string using the defined template.
@@ -118,13 +57,7 @@ module Lumberjack
         string = string.strip
         return if string.length == 0
 
-        if buffer_size > 1
-          @buffer << string
-          flush if @buffer.size >= buffer_size
-        else
-          before_flush if respond_to?(:before_flush, true)
-          write_to_stream(string)
-        end
+        write_to_stream(string)
       end
 
       # Close the underlying stream.
@@ -139,8 +72,6 @@ module Lumberjack
       #
       # @return [void]
       def flush
-        lines = @buffer.pop! { before_flush if respond_to?(:before_flush, true) }
-        write_to_stream(lines) if lines
         stream.flush if stream.respond_to?(:flush)
       end
 
@@ -178,21 +109,7 @@ module Lumberjack
 
       private
 
-      def write_to_stream(lines)
-        return if lines.empty?
-
-        if lines.is_a?(Array)
-          lines.each do |line|
-            write_line(line)
-          end
-        else
-          write_line(lines)
-        end
-
-        stream.flush if stream.respond_to?(:flush)
-      end
-
-      def write_line(line)
+      def write_to_stream(line)
         out = "#{line}#{Lumberjack::LINE_SEPARATOR}"
         begin
           begin

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -12,22 +12,12 @@ module Lumberjack
   #
   # Log entries are written to a logging Device if their severity meets or exceeds the log level.
   #
-  # Devices may use buffers internally and the log entries are not guaranteed to be written until you call
-  # the +flush+ method. Sometimes this can result in problems when trying to track down extraordinarily
-  # long running sections of code since it is likely that none of the messages logged before the long
-  # running code will appear in the log until the entire process finishes. You can set the +:flush_seconds+
-  # option on the constructor to force the device to be flushed periodically. This will create a new
-  # monitoring thread, but its use is highly recommended.
-  #
   # Each log entry records the log message and severity along with the time it was logged, the
   # program name, process id, and an optional hash of tags. The message will be converted to a string, but
   # otherwise, it is up to the device how these values are recorded. Messages are converted to strings
   # using a Formatter associated with the logger.
   class Logger < ::Logger
     include ContextLogger
-
-    # The time that the device was last flushed.
-    attr_reader :last_flushed_at
 
     attr_accessor :formatter
 
@@ -64,12 +54,10 @@ module Lumberjack
     # @param template [String] The template to use for serializing log entries to a string.
     # @param message_formatter [Lumberjack::Formatter] The MessageFormatter to use for formatting log messages.
     # @param tag_formatter [Lumberjack::TagFormatter] The TagFormatter to use for formatting tags.
-    # @param flush_seconds [Numeric] The maximum number of seconds between automatic calls to flush the logs.
     def initialize(logdev, shift_age = 0, shift_size = 1048576,
       level: DEBUG, progname: nil, formatter: nil, datetime_format: nil,
       binmode: false, shift_period_suffix: "%Y%m%d",
-      template: nil, message_formatter: nil, tag_formatter: nil, flush_seconds: nil,
-      **kwargs)
+      template: nil, message_formatter: nil, tag_formatter: nil, **kwargs)
       init_fiber_locals!
 
       # Include standard args that affect devices with the optional kwargs which may
@@ -87,9 +75,6 @@ module Lumberjack
       self.datetime_format = datetime_format if datetime_format
 
       @closed = false # TODO
-
-      @last_flushed_at = Time.now
-      create_flusher_thread(flush_seconds.to_f) if flush_seconds.to_f > 0
     end
 
     # Get the logging device that is used to write log entries.
@@ -145,7 +130,6 @@ module Lumberjack
     # @return [void]
     def flush
       device.flush
-      @last_flushed_at = Time.now
       nil
     end
 
@@ -319,25 +303,6 @@ module Lumberjack
       end
 
       positional_arg_count == 4 && !has_forbidden_args
-    end
-
-    # Create a thread that will periodically call flush.
-    def create_flusher_thread(flush_seconds) # :nodoc:
-      if flush_seconds > 0
-        begin
-          logger = self
-          Thread.new do
-            until closed?
-              begin
-                sleep(flush_seconds)
-                logger.flush if Time.now - logger.last_flushed_at >= flush_seconds
-              rescue => e
-                warn("Error flushing log: #{e.inspect}")
-              end
-            end
-          end
-        end
-      end
     end
   end
 end

--- a/spec/lumberjack/device/writer_spec.rb
+++ b/spec/lumberjack/device/writer_spec.rb
@@ -8,22 +8,6 @@ RSpec.describe Lumberjack::Device::Writer do
   let(:stream) { StringIO.new }
   let(:entry) { Lumberjack::LogEntry.new(time, Logger::INFO, "test message", "app", 12345, "foo" => "ABCD") }
 
-  it "should buffer output and not write directly to the stream" do
-    device = Lumberjack::Device::Writer.new(stream, template: ":message", buffer_size: 32767)
-    device.write(entry)
-    expect(stream.string).to eq("")
-    device.flush
-    expect(stream.string).to eq("test message#{Lumberjack::LINE_SEPARATOR}")
-  end
-
-  it "should flush the buffer when it gets to the specified size" do
-    device = Lumberjack::Device::Writer.new(stream, buffer_size: 15, template: ":message")
-    device.write(entry)
-    expect(stream.string).to eq("")
-    device.write(entry)
-    expect(stream.string).to eq("test message#{Lumberjack::LINE_SEPARATOR}test message#{Lumberjack::LINE_SEPARATOR}")
-  end
-
   it "should sync the stream and flush it when the device is flushed" do
     # Create an IO like object that require flush to be called
     io = Object.new
@@ -58,24 +42,12 @@ RSpec.describe Lumberjack::Device::Writer do
 
     io.init
 
-    device = Lumberjack::Device::Writer.new(io, template: ":message", buffer_size: 32767)
+    device = Lumberjack::Device::Writer.new(io, template: ":message")
     device.write(entry)
     expect(io.string).to eq("")
     device.flush
     expect(io.string).to eq("test message#{Lumberjack::LINE_SEPARATOR}")
     expect(io.sync).to eq(true)
-  end
-
-  it "should be able to set the buffer size" do
-    device = Lumberjack::Device::Writer.new(stream, buffer_size: 15)
-    expect(device.buffer_size).to eq(15)
-    device.buffer_size = 100
-    expect(device.buffer_size).to eq(100)
-  end
-
-  it "should have a default buffer size of 0" do
-    device = Lumberjack::Device::Writer.new(stream)
-    expect(device.buffer_size).to eq(0)
   end
 
   it "should write entries out to the stream with a default template" do


### PR DESCRIPTION
- Removed internal buffer from the `Lumberjack::Device::Writer` class. This funcationality was more useful in the days of slower I/O operations when logs were written to spinning hard disks. The functionality is no longer as useful and is not worth the overhead. The `Lumberjack::Logger.last_flushed_at` method has also been removed.
