### PR TITLE
Add trace log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added IO compatibility methods for logging. Calling `logger.write`, `logger.puts`, `logger.print`, or `logger.printf` will write log messages with a severity level of UNKNOWN.
 - Added `Lumberjack::Device::Test` class for use in testing logging functionality. This device will buffer log entries and has `match?` and `include?` methods that can be used for assertions in tests.
 - Added support for standard library `Logger::Formatter`. This is for compatibility with the standard library `Logger`. If a standard library logger is passed to `Lumberjack::Logger` as the formatter, it will override the template when writing to a stream. Tags are not available in the output when using a standard library formatter.
+- Added `TRACE` logging level for logging at an even lower level than `DEBUG`. `Lumberjack::Logger#trace` can be used to log messages at this level.
 
 ### Changed
 

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -10,9 +10,9 @@ module Lumberjack
   LINE_SEPARATOR = ((RbConfig::CONFIG["host_os"] =~ /mswin/i) ? "\r\n" : "\n")
 
   require_relative "lumberjack/context"
+  require_relative "lumberjack/context_logger"
   require_relative "lumberjack/fiber_locals"
   require_relative "lumberjack/io_compatibility"
-  require_relative "lumberjack/context_logger"
   require_relative "lumberjack/log_entry"
   require_relative "lumberjack/log_entry_matcher"
   require_relative "lumberjack/device"

--- a/lib/lumberjack/context_logger.rb
+++ b/lib/lumberjack/context_logger.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "fiber_locals"
+require_relative "io_compatibility"
+require_relative "severity"
+
 module Lumberjack
   module ContextLogger
+    # Constant used for setting trace log level.
+    TRACE = Severity::TRACE
+
     class << self
       def included(base)
         base.include(FiberLocals) unless base.include?(FiberLocals)
@@ -211,6 +218,33 @@ module Lumberjack
     # @return [void]
     def debug!
       self.level = Logger::DEBUG
+    end
+
+    # Log a +TRACE+ message. The message can be passed in either the +message+ argument or in a block.
+    # Trace logs are a level lower than debug and are generally used to log code execution paths for
+    # low level debugging.
+    #
+    # @param [Object] message_or_progname_or_tags The message to log or progname
+    #   if the message is passed in a block.
+    # @param [String, Hash] progname_or_tags The name of the program that is logging the message or tags
+    #   if the message is passed in a block.
+    # @return [void]
+    def trace(message_or_progname_or_tags = nil, progname_or_tags = nil, &block)
+      call_add_entry(TRACE, message_or_progname_or_tags, progname_or_tags, &block)
+    end
+
+    # Return +true+ if +TRACE+ messages are being logged.
+    #
+    # @return [Boolean]
+    def trace?
+      level <= TRACE
+    end
+
+    # Set the log level to trace.
+    #
+    # @return [void]
+    def trace!
+      self.level = TRACE
     end
 
     # Log a message when the severity is not known. Unknown messages will always appear in the log.

--- a/lib/lumberjack/severity.rb
+++ b/lib/lumberjack/severity.rb
@@ -3,14 +3,21 @@
 module Lumberjack
   # The standard severity levels for logging messages.
   module Severity
+    TRACE = -1
+
+    TRACE_LABEL = "TRACE"
+    private_constant :TRACE_LABEL
+
     SEVERITY_LABELS = %w[DEBUG INFO WARN ERROR FATAL ANY].freeze
     private_constant :SEVERITY_LABELS
+
     class << self
       # Convert a severity level to a label.
       #
       # @param [Integer] severity The severity level to convert.
       # @return [String] The severity label.
       def level_to_label(severity)
+        return TRACE_LABEL if severity == TRACE
         SEVERITY_LABELS[severity] || SEVERITY_LABELS.last
       end
 
@@ -19,7 +26,8 @@ module Lumberjack
       # @param [String, Symbol] label The severity label to convert.
       # @return [Integer] The severity level.
       def label_to_level(label)
-        SEVERITY_LABELS.index(label.to_s.upcase) || Logger::Severity::UNKNOWN
+        label = label.to_s.upcase
+        SEVERITY_LABELS.index(label) || ((label == TRACE_LABEL) ? Logger::TRACE : Logger::UNKNOWN)
       end
 
       # Coerce a value to a severity level.
@@ -27,8 +35,8 @@ module Lumberjack
       # @param [Integer, String, Symbol] value The value to coerce.
       # @return [Integer] The severity level.
       def coerce(value)
-        if value.is_a?(Integer)
-          value
+        if value.is_a?(Numeric)
+          value.to_i
         else
           label_to_level(value)
         end

--- a/lib/lumberjack/severity.rb
+++ b/lib/lumberjack/severity.rb
@@ -27,7 +27,7 @@ module Lumberjack
       # @return [Integer] The severity level.
       def label_to_level(label)
         label = label.to_s.upcase
-        SEVERITY_LABELS.index(label) || ((label == TRACE_LABEL) ? Logger::TRACE : Logger::UNKNOWN)
+        SEVERITY_LABELS.index(label) || ((label == TRACE_LABEL) ? TRACE : Logger::UNKNOWN)
       end
 
       # Coerce a value to a severity level.

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -426,12 +426,12 @@ describe Lumberjack::ContextLogger do
     end
   end
 
-  [:fatal, :error, :warn, :info, :debug, :unknown].each do |severity|
+  [:fatal, :error, :warn, :info, :debug, :unknown, :trace].each do |severity|
     describe "##{severity}" do
       it "logs an entry as #{severity}" do
         logger.public_send(severity, "Message")
         expect(logger.entries.first).to eq({
-          severity: Logger.const_get(severity.to_s.upcase),
+          severity: Lumberjack::Logger.const_get(severity.to_s.upcase),
           message: "Message",
           progname: nil,
           tags: nil

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -431,7 +431,7 @@ describe Lumberjack::ContextLogger do
       it "logs an entry as #{severity}" do
         logger.public_send(severity, "Message")
         expect(logger.entries.first).to eq({
-          severity: Lumberjack::Logger.const_get(severity.to_s.upcase),
+          severity: Lumberjack::Severity.coerce(severity),
           message: "Message",
           progname: nil,
           tags: nil

--- a/spec/lumberjack/severity_spec.rb
+++ b/spec/lumberjack/severity_spec.rb
@@ -3,21 +3,50 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Severity do
-  it "should convert a level to a label" do
-    expect(Lumberjack::Severity.level_to_label(Logger::DEBUG)).to eq("DEBUG")
-    expect(Lumberjack::Severity.level_to_label(Logger::INFO)).to eq("INFO")
-    expect(Lumberjack::Severity.level_to_label(Logger::WARN)).to eq("WARN")
-    expect(Lumberjack::Severity.level_to_label(Logger::ERROR)).to eq("ERROR")
-    expect(Lumberjack::Severity.level_to_label(Logger::FATAL)).to eq("FATAL")
-    expect(Lumberjack::Severity.level_to_label(100)).to eq("ANY")
+  describe "#level_to_label" do
+    it "converts a level to a label" do
+      expect(Lumberjack::Severity.level_to_label(Logger::DEBUG)).to eq("DEBUG")
+      expect(Lumberjack::Severity.level_to_label(Logger::INFO)).to eq("INFO")
+      expect(Lumberjack::Severity.level_to_label(Logger::WARN)).to eq("WARN")
+      expect(Lumberjack::Severity.level_to_label(Logger::ERROR)).to eq("ERROR")
+      expect(Lumberjack::Severity.level_to_label(Logger::FATAL)).to eq("FATAL")
+      expect(Lumberjack::Severity.level_to_label(Lumberjack::Logger::TRACE)).to eq("TRACE")
+      expect(Lumberjack::Severity.level_to_label(Logger::UNKNOWN)).to eq("ANY")
+      expect(Lumberjack::Severity.level_to_label(100)).to eq("ANY")
+    end
   end
 
-  it "should convert a label to a level" do
-    expect(Lumberjack::Severity.label_to_level("DEBUG")).to eq(Logger::DEBUG)
-    expect(Lumberjack::Severity.label_to_level(:info)).to eq(Logger::INFO)
-    expect(Lumberjack::Severity.label_to_level(:warn)).to eq(Logger::WARN)
-    expect(Lumberjack::Severity.label_to_level("Error")).to eq(Logger::ERROR)
-    expect(Lumberjack::Severity.label_to_level("FATAL")).to eq(Logger::FATAL)
-    expect(Lumberjack::Severity.label_to_level("???")).to eq(Logger::UNKNOWN)
+  describe "#label_to_level" do
+    it "converts a label to a level" do
+      expect(Lumberjack::Severity.label_to_level("DEBUG")).to eq(Logger::DEBUG)
+      expect(Lumberjack::Severity.label_to_level(:info)).to eq(Logger::INFO)
+      expect(Lumberjack::Severity.label_to_level(:warn)).to eq(Logger::WARN)
+      expect(Lumberjack::Severity.label_to_level("Error")).to eq(Logger::ERROR)
+      expect(Lumberjack::Severity.label_to_level("FATAL")).to eq(Logger::FATAL)
+      expect(Lumberjack::Severity.label_to_level("TRACE")).to eq(Lumberjack::Logger::TRACE)
+      expect(Lumberjack::Severity.label_to_level("???")).to eq(Logger::UNKNOWN)
+    end
+  end
+
+  describe "#coerce" do
+    it "coerces integer levels to themselves" do
+      expect(Lumberjack::Severity.coerce(Logger::DEBUG)).to eq(Logger::DEBUG)
+    end
+
+    it "coerces a symbol to a level" do
+      expect(Lumberjack::Severity.coerce(:debug)).to eq(Logger::DEBUG)
+    end
+
+    it "coerces a string to a level" do
+      expect(Lumberjack::Severity.coerce("Info")).to eq(Logger::INFO)
+    end
+
+    it "coerces unknown values to UNKNOWN" do
+      expect(Lumberjack::Severity.coerce("???")).to eq(Logger::UNKNOWN)
+    end
+
+    it "coerces trace labels to TRACE" do
+      expect(Lumberjack::Severity.coerce("TRACE")).to eq(Lumberjack::Logger::TRACE)
+    end
   end
 end


### PR DESCRIPTION
- Added `TRACE` logging level for logging at an even lower level than `DEBUG`. `Lumberjack::Logger#trace` can be used to log messages at this level.
