### PR TITLE
Add autoflush option to enable synchrounous IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Lumberjack::Logger#tag` now returns a `Lumberjack::ContextLogger` object when called without a block. This allows for chaining methods on the logger while still having the tags applied.
 - `Lumberjack::Logger#add_entry` does not check the logger level and will add the entry regardless of the severity. This method is an internal API method and is now documented as such.
 - Logging to files will now use the standard library `Logger::LogDevice` class for file output and rolling.
+- The `Lumberjack::Device::Writer` class now takes an `autoflush` option to enable synchronous I/O. Previously, this was the default.
 
 ### Removed
 

--- a/lib/lumberjack/device/writer.rb
+++ b/lib/lumberjack/device/writer.rb
@@ -24,7 +24,7 @@ module Lumberjack
       # @param [Hash] options The options for the device.
       def initialize(stream, options = {})
         @stream = stream
-        @stream.sync = true if @stream.respond_to?(:sync=)
+        @stream.sync = true if @stream.respond_to?(:sync=) && options[:autoflush]
 
         @binmode = options[:binmode]
 

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Lumberjack::ContextLogger do
+RSpec.describe Lumberjack::ContextLogger do
   let(:logger) { TestContextLogger.new }
   let(:logger_with_default_context) { TestContextLogger.new(default_context) }
   let(:default_context) { Lumberjack::Context.new }

--- a/spec/lumberjack/device/file_spec.rb
+++ b/spec/lumberjack/device/file_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Lumberjack::Device::File do
+RSpec.describe Lumberjack::Device::File do
   let(:out) { StringIO.new }
 
   it "wraps a ::Logger::LogDevice" do

--- a/spec/lumberjack/device/test_spec.rb
+++ b/spec/lumberjack/device/test_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Lumberjack::Device::Test do
+RSpec.describe Lumberjack::Device::Test do
   let(:device) { Lumberjack::Device::Test.new }
 
   describe "#max_entries" do

--- a/spec/lumberjack/entry_formatter_spec.rb
+++ b/spec/lumberjack/entry_formatter_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Lumberjack::EntryFormatter do
+RSpec.describe Lumberjack::EntryFormatter do
   describe "building formatters" do
     it "starts with a default message formatter and no tag formatter" do
       entry_formatter = Lumberjack::EntryFormatter.new

--- a/spec/lumberjack/io_compatibility_spec.rb
+++ b/spec/lumberjack/io_compatibility_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Lumberjack::IOCompatibility do
+RSpec.describe Lumberjack::IOCompatibility do
   let(:logger) { TestContextLogger.new }
   it "can write to the log" do
     logger.write("Hello, world")

--- a/spec/lumberjack/local_logger_spec.rb
+++ b/spec/lumberjack/local_logger_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Lumberjack::LocalLogger do
+RSpec.describe Lumberjack::LocalLogger do
   let(:logger) { TestContextLogger.new(Lumberjack::Context.new) }
 
   it "logs to the parent logger" do

--- a/spec/lumberjack/log_entry_matcher_spec.rb
+++ b/spec/lumberjack/log_entry_matcher_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Lumberjack::LogEntryMatcher do
+RSpec.describe Lumberjack::LogEntryMatcher do
   describe "#match?" do
     let(:entry) { Lumberjack::LogEntry.new(Time.now, Logger::INFO, "Test message", "AppName", Process.pid, tags) }
     let(:tags) { {} }

--- a/spec/lumberjack/utils_spec.rb
+++ b/spec/lumberjack/utils_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Lumberjack::Utils do
+RSpec.describe Lumberjack::Utils do
   describe ".hostname" do
     it "returns the hostname in UTF-8 encoding" do
       expect(Lumberjack::Utils.hostname).to be_a(String)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,10 @@ require_relative "../lib/lumberjack"
 
 RSpec.configure do |config|
   config.warnings = true
+  config.disable_monkey_patching!
+  config.default_formatter = "doc" if config.files_to_run.one?
   config.order = :random
+  Kernel.srand config.seed
 
   config.around(:each, :suppress_warnings) do |example|
     save_val = ENV["LUMBERJACK_NO_DEPRECATION_WARNINGS"]


### PR DESCRIPTION
- The `Lumberjack::Device::Writer` class now takes an `autoflush` option to enable synchronous I/O. Previously, this was the default.