### PR TITLE
Add default_severity to control severity of appendend log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Lumberjack::Logger#tag!` as the preferred method for adding global tags to a logger.
 - Added `Lumberjack::Logger#untag!` and `Lumberjack::Logger#untag!` to remove global tags from a logger.
 - Added `Lumberjack::Logger#context?` as a replacement for `Lumberjack::Logger.in_tag_context?`.
-- Added IO compatibility methods for logging. Calling `logger.write`, `logger.puts`, `logger.print`, or `logger.printf` will write log messages with a severity level of UNKNOWN.
+- Added IO compatibility methods for logging. Calling `logger.write`, `logger.puts`, `logger.print`, or `logger.printf` will write log entries. The severity of the log entries can be set with `default_severity`.
 - Added `Lumberjack::Device::Test` class for use in testing logging functionality. This device will buffer log entries and has `match?` and `include?` methods that can be used for assertions in tests.
 - Added support for standard library `Logger::Formatter`. This is for compatibility with the standard library `Logger`. If a standard library logger is passed to `Lumberjack::Logger` as the formatter, it will override the template when writing to a stream. Tags are not available in the output when using a standard library formatter.
 - Classes can now define their own formatting in logs by implementing the `to_log_format` method. If an object responds to this method, it will be called in lieu of looking up the formatter by class. This allows a pattern of defining log formatting along with the code rather than in a an initializer.

--- a/lib/lumberjack/context_logger.rb
+++ b/lib/lumberjack/context_logger.rb
@@ -271,7 +271,22 @@ module Lumberjack
     # @param [Object] msg The message to log.
     # @return [void]
     def <<(msg)
-      add_entry(Logger::UNKNOWN, msg)
+      add_entry(default_severity, msg)
+    end
+
+    # The default severity for log entries written with the << operator. Defaults to Logger::UNKNOWN.
+    #
+    # @return [Integer] The default severity level.
+    def default_severity
+      @default_severity ||= Logger::UNKNOWN
+    end
+
+    # Set a default severity that is used when adding messages with the << operator.
+    #
+    # @param [Integer, String, Symbol] severity The default severity level.
+    # @return [void]
+    def default_severity=(severity)
+      @default_severity = Severity.coerce(severity)
     end
 
     # Set a hash of tags on logger. If a block is given, the tags will only be set

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -161,6 +161,17 @@ RSpec.describe Lumberjack::ContextLogger do
         tags: nil
       })
     end
+
+    it "will use the default severity to log the message" do
+      logger.default_severity = Logger::INFO
+      logger << "Test message"
+      expect(logger.entries.last).to eq({
+        severity: Logger::INFO,
+        message: "Test message",
+        progname: nil,
+        tags: nil
+      })
+    end
   end
 
   describe "#context" do


### PR DESCRIPTION
Allows customizing the severity used when writing to loggers as a stream.