### PR TITLE
Isolate default_severity context on loggers

### DIFF
--- a/lib/lumberjack/context.rb
+++ b/lib/lumberjack/context.rb
@@ -6,12 +6,14 @@ module Lumberjack
     attr_reader :tags
     attr_reader :level
     attr_reader :progname
+    attr_reader :default_severity
 
     # @param parent_context [Context] A parent context to inherit tags from.
     def initialize(parent_context = nil)
       @tags = nil
       @level = nil
       @progname = nil
+      @default_severity = nil
 
       if parent_context
         @tags = parent_context.tags.dup if parent_context.tags
@@ -21,7 +23,7 @@ module Lumberjack
     end
 
     def level=(value)
-      value = Lumberjack::Severity.coerce(value) unless value.nil?
+      value = Severity.coerce(value) unless value.nil?
       @level = value
     end
 
@@ -65,6 +67,11 @@ module Lumberjack
     # @return [void]
     def delete(*keys)
       tag_context.delete(*keys)
+    end
+
+    def default_severity=(value)
+      value = Severity.coerce(value) unless value.nil?
+      @default_severity = value
     end
 
     # Clear all the context data.

--- a/lib/lumberjack/context_logger.rb
+++ b/lib/lumberjack/context_logger.rb
@@ -81,6 +81,23 @@ module Lumberjack
       end
     end
 
+    # Get the default severity used when writing log messages directly to a stream.
+    #
+    # @return [Integer] The default severity level.
+    def default_severity
+      current_context&.default_severity || default_context&.default_severity || Logger::UNKNOWN
+    end
+
+    # Set the default severity used when writing log messages directly to a stream
+    # for the current context.
+    #
+    # @param [Integer, Symbol, String] value The default severity level.
+    # @return [void]
+    def default_severity=(value)
+      ctx = current_context
+      ctx.default_severity = value if ctx
+    end
+
     # ::Logger compatible method to add a log entry.
     #
     # @param [Integer, Symbol, String] severity The severity of the message.
@@ -272,21 +289,6 @@ module Lumberjack
     # @return [void]
     def <<(msg)
       add_entry(default_severity, msg)
-    end
-
-    # The default severity for log entries written with the << operator. Defaults to Logger::UNKNOWN.
-    #
-    # @return [Integer] The default severity level.
-    def default_severity
-      @default_severity ||= Logger::UNKNOWN
-    end
-
-    # Set a default severity that is used when adding messages with the << operator.
-    #
-    # @param [Integer, String, Symbol] severity The default severity level.
-    # @return [void]
-    def default_severity=(severity)
-      @default_severity = Severity.coerce(severity)
     end
 
     # Set a hash of tags on logger. If a block is given, the tags will only be set

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -163,7 +163,8 @@ RSpec.describe Lumberjack::ContextLogger do
     end
 
     it "will use the default severity to log the message" do
-      logger.default_severity = Logger::INFO
+      logger = TestContextLogger.new(Lumberjack::Context.new)
+      logger.default_severity = :info
       logger << "Test message"
       expect(logger.entries.last).to eq({
         severity: Logger::INFO,

--- a/spec/lumberjack/context_spec.rb
+++ b/spec/lumberjack/context_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe Lumberjack::Context do
     end
   end
 
+  describe "#default_severity" do
+    it "should have a default severity" do
+      context = Lumberjack::Context.new
+      expect(context.default_severity).to be_nil
+      context.default_severity = :info
+      expect(context.default_severity).to eq(Logger::INFO)
+      context.default_severity = nil
+      expect(context.default_severity).to be_nil
+    end
+  end
+
   describe "#tag" do
     it "should have tags" do
       context = Lumberjack::Context.new

--- a/spec/lumberjack/io_compatibility_spec.rb
+++ b/spec/lumberjack/io_compatibility_spec.rb
@@ -3,7 +3,8 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::IOCompatibility do
-  let(:logger) { TestContextLogger.new }
+  let(:logger) { TestContextLogger.new(Lumberjack::Context.new) }
+
   it "can write to the log" do
     logger.write("Hello, world")
     expect(logger.entries).to eq([


### PR DESCRIPTION
Make default severity a context so that it can be overriden on local loggers or in blocks.