### PR TITLE
Rename LocalLogger to ForkedLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Tag formatters can now add class formatters by class name using the `add_class` method. This allows setting a class formatter before the class has been loaded.
 - A tag format can now be passed to the `Lumberjack::Template` class to specify how to format tag name/value pairs. The default is "[%s:%s]".
 - Added `TRACE` logging level for logging at an even lower level than `DEBUG`. `Lumberjack::Logger#trace` can be used to log messages at this level.
-- Added `Lumberjack::LocalLogger` which is a wrapper around a logger with a separate context. A local logger has a parent logger which it will write it's log entries through. It will inherit the level, progname, and tags from a parent logger, but has its own local context isolated from the parent logger. You can change the level, progname, and add tags on the local logger without impacting the parent logger. Local loggers can be gotten from the current logger by calling `Lumberjack::Logger#local_logger`.
+- Added `Lumberjack::ForkedLogger` which is a wrapper around a logger with a separate context. A local logger has a parent logger which it will write it's log entries through. It will inherit the level, progname, and tags from a parent logger, but has its own local context isolated from the parent logger. You can change the level, progname, and add tags on the local logger without impacting the parent logger. Local loggers can be gotten from the current logger by calling `Lumberjack::Logger#fork`.
 - Added `Lumberjack::Utils.current_line` as a helper method for getting the current line of code.
 
 ### Changed

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -20,7 +20,7 @@ module Lumberjack
   require_relative "lumberjack/device"
   require_relative "lumberjack/entry_formatter"
   require_relative "lumberjack/formatter"
-  require_relative "lumberjack/local_logger"
+  require_relative "lumberjack/forked_logger"
   require_relative "lumberjack/logger"
   require_relative "lumberjack/rack"
   require_relative "lumberjack/severity"

--- a/lib/lumberjack/context_logger.rb
+++ b/lib/lumberjack/context_logger.rb
@@ -353,8 +353,21 @@ module Lumberjack
       end
     end
 
-    def local_logger(level: nil, progname: nil, attributes: nil)
-      logger = LocalLogger.new(self)
+    # Forks a new logger with a new context that will send output through this logger.
+    # The new logger will inherit the level, progname, and attributes of the current logger
+    # context. Any changes to those values, though, will be isolated to just the forked logger.
+    # Any calls to log messages will be forwarded to the parent logger for output to the
+    # logging device.
+    #
+    # @param level [Integer, String, Symbol, nil] The level to set on the new logger. If this
+    #   is not specified, then the level on the parent logger will be used.
+    # @param progname [String, nil] The progname to set on the new logger. If this is not specified,
+    #   then the progname on the parent logger will be used.
+    # @param attributes [Hash, nil] The attributes to set on the new logger. The forked logger will
+    #   inherit all attributes from the current logging context.
+    # @return [ForkedLogger]
+    def fork(level: nil, progname: nil, attributes: nil)
+      logger = ForkedLogger.new(self)
       logger.level = level if level
       logger.progname = progname if progname
       logger.tag!(attributes) if attributes

--- a/lib/lumberjack/forked_logger.rb
+++ b/lib/lumberjack/forked_logger.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Lumberjack
-  class LocalLogger < Logger
+  class ForkedLogger < Logger
     include ContextLogger
 
     attr_reader :parent_logger

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -435,35 +435,35 @@ RSpec.describe Lumberjack::ContextLogger do
     end
   end
 
-  describe "#local_logger" do
+  describe "#fork" do
     it "returns a local logger that has an isolated context from the current logger" do
-      local_logger = logger.local_logger
-      expect(local_logger.level).to eq logger.level
-      local_logger.level = :warn
-      expect(local_logger.level).to_not eq logger.level
+      forked_logger = logger.fork
+      expect(forked_logger.level).to eq logger.level
+      forked_logger.level = :warn
+      expect(forked_logger.level).to_not eq logger.level
 
-      expect(local_logger.progname).to eq logger.progname
-      local_logger.progname = "LocalLogger"
-      expect(local_logger.progname).to_not eq logger.progname
+      expect(forked_logger.progname).to eq logger.progname
+      forked_logger.progname = "ForkedLogger"
+      expect(forked_logger.progname).to_not eq logger.progname
 
-      expect(local_logger.attributes).to eq logger.attributes
-      local_logger.tag!(foo: "bar")
-      expect(local_logger.attributes).to_not eq logger.attributes
+      expect(forked_logger.attributes).to eq logger.attributes
+      forked_logger.tag!(foo: "bar")
+      expect(forked_logger.attributes).to_not eq logger.attributes
     end
 
     it "can set the level on the local logger" do
-      local_logger = logger.local_logger(level: :warn)
-      expect(local_logger.level).to eq(Logger::WARN)
+      forked_logger = logger.fork(level: :warn)
+      expect(forked_logger.level).to eq(Logger::WARN)
     end
 
     it "can set the progname on the local logger" do
-      local_logger = logger.local_logger(progname: "LocalLogger")
-      expect(local_logger.progname).to eq("LocalLogger")
+      forked_logger = logger.fork(progname: "ForkedLogger")
+      expect(forked_logger.progname).to eq("ForkedLogger")
     end
 
     it "can set attributes on the local logger" do
-      local_logger = logger.local_logger(attributes: {foo: "bar"})
-      expect(local_logger.attributes).to eq({"foo" => "bar"})
+      forked_logger = logger.fork(attributes: {foo: "bar"})
+      expect(forked_logger.attributes).to eq({"foo" => "bar"})
     end
   end
 

--- a/spec/lumberjack/forked_logger_spec.rb
+++ b/spec/lumberjack/forked_logger_spec.rb
@@ -2,13 +2,13 @@
 
 require "spec_helper"
 
-RSpec.describe Lumberjack::LocalLogger do
+RSpec.describe Lumberjack::ForkedLogger do
   let(:logger) { TestContextLogger.new(Lumberjack::Context.new) }
 
   it "logs to the parent logger" do
-    local_logger = Lumberjack::LocalLogger.new(logger)
+    forked_logger = Lumberjack::ForkedLogger.new(logger)
 
-    local_logger.info("Test message")
+    forked_logger.info("Test message")
 
     expect(logger.entries.first).to eq({
       severity: Logger::INFO,
@@ -20,16 +20,16 @@ RSpec.describe Lumberjack::LocalLogger do
 
   it "inherits the parent logger's level" do
     logger.level = Logger::WARN
-    local_logger = Lumberjack::LocalLogger.new(logger)
-    expect(local_logger.level).to eq(Logger::WARN)
+    forked_logger = Lumberjack::ForkedLogger.new(logger)
+    expect(forked_logger.level).to eq(Logger::WARN)
   end
 
   it "will log in the parent logger even if the parent logger has a higher threshold" do
     logger.level = :warn
-    local_logger = Lumberjack::LocalLogger.new(logger)
-    local_logger.level = :info
+    forked_logger = Lumberjack::ForkedLogger.new(logger)
+    forked_logger.level = :info
     expect(logger.level).to eq(Logger::WARN)
-    local_logger.info("Test message")
+    forked_logger.info("Test message")
     expect(logger.entries.first).to eq({
       severity: Logger::INFO,
       message: "Test message",
@@ -39,9 +39,9 @@ RSpec.describe Lumberjack::LocalLogger do
   end
 
   it "allows setting attributes on the local logger" do
-    local_logger = Lumberjack::LocalLogger.new(logger)
-    local_logger.tag!(test: "value")
-    local_logger.info("Test message")
+    forked_logger = Lumberjack::ForkedLogger.new(logger)
+    forked_logger.tag!(test: "value")
+    forked_logger.info("Test message")
     expect(logger.attributes).to be_empty
     expect(logger.entries.first).to eq({
       severity: Logger::INFO,
@@ -52,9 +52,9 @@ RSpec.describe Lumberjack::LocalLogger do
   end
 
   it "allows setting the progname on the local logger" do
-    local_logger = Lumberjack::LocalLogger.new(logger)
-    local_logger.progname = "TestProgname"
-    local_logger.info("Test message")
+    forked_logger = Lumberjack::ForkedLogger.new(logger)
+    forked_logger.progname = "TestProgname"
+    forked_logger.info("Test message")
     expect(logger.progname).to be_nil
     expect(logger.entries.first).to eq({
       severity: Logger::INFO,


### PR DESCRIPTION
"Fork" captures the essence of the concept better than "Local".