### PR TITLE
Standardize on in_context? method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Added `Lumberjack::EntryFormatter` class to provide a unified interface for formatting log entry details. Going forward this is the preferred way to define log entry formatters. `Lumberjack::Logger#formatter` now returns an entry formatter.
 - Added `Lumberjack::Logger#tag!` as the preferred method for adding global tags to a logger.
 - Added `Lumberjack::Logger#untag!` and `Lumberjack::Logger#untag!` to remove global tags from a logger.
-- Added `Lumberjack::Logger#context?` as a replacement for `Lumberjack::Logger.in_tag_context?`.
+- Added `Lumberjack::Logger#in_context?` as a replacement for `Lumberjack::Logger.in_tag_context?` and `Lumberjack.in_context?` as a replacement for `Lumberjack::Logger.context?`.
 - Added IO compatibility methods for logging. Calling `logger.write`, `logger.puts`, `logger.print`, or `logger.printf` will write log entries. The severity of the log entries can be set with `default_severity`.
 - Added `Lumberjack::Device::Test` class for use in testing logging functionality. This device will buffer log entries and has `match?` and `include?` methods that can be used for assertions in tests.
 - Added support for standard library `Logger::Formatter`. This is for compatibility with the standard library `Logger`. If a standard library logger is passed to `Lumberjack::Logger` as the formatter, it will override the template when writing to a stream. Tags are not available in the output when using a standard library formatter.

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -79,8 +79,14 @@ module Lumberjack
     # Return true if inside a context block.
     #
     # @return [Boolean]
-    def context?
+    def in_context?
       !!@global_contexts[Fiber.current.object_id]
+    end
+
+    def context?
+      Utils.deprecated(:context?, "Use in_context? instead.") do
+        in_context?
+      end
     end
 
     # Return attributes that will be applied to all Lumberjack loggers.

--- a/lib/lumberjack/context_logger.rb
+++ b/lib/lumberjack/context_logger.rb
@@ -456,7 +456,7 @@ module Lumberjack
     # Return true if the thread is currently in a context block with a local context.
     #
     # @return [Boolean]
-    def context?
+    def in_context?
       !!local_context
     end
 

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -219,7 +219,7 @@ module Lumberjack
     # Use context? instead
     #
     # @return [Boolean]
-    # @deprecated Use {#context?} instead.
+    # @deprecated Use {#in_context?} instead.
     def in_tag_context?
       Utils.deprecated(:in_tag_context?, "Use context? instead.") do
         context?

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -224,13 +224,13 @@ RSpec.describe Lumberjack::ContextLogger do
     end
   end
 
-  describe "#context?" do
+  describe "#in_context?" do
     it "returns true inside a context block" do
-      expect(logger.context?).to be false
+      expect(logger.in_context?).to be false
       logger.context do
-        expect(logger.context?).to be true
+        expect(logger.in_context?).to be true
       end
-      expect(logger.context?).to be false
+      expect(logger.in_context?).to be false
     end
   end
 

--- a/spec/lumberjack/rack/context_spec.rb
+++ b/spec/lumberjack/rack/context_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe Lumberjack::Rack::Context do
   it "should create a context for a request" do
-    app = lambda { |env| [200, {"Context" => Lumberjack.context?}, ["OK"]] }
+    app = lambda { |env| [200, {"Context" => Lumberjack.in_context?}, ["OK"]] }
     handler = Lumberjack::Rack::Context.new(app)
 
     response = handler.call("Content-Type" => "text/plain", "action_dispatch.request_id" => "0123-4567-89ab-cdef")

--- a/spec/lumberjack_spec.rb
+++ b/spec/lumberjack_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Lumberjack do
     end
 
     it "should determine if it is inside a context block" do
-      expect(Lumberjack.context?).to eq false
+      expect(Lumberjack.in_context?).to eq false
       Lumberjack.context do
-        expect(Lumberjack.context?).to eq true
+        expect(Lumberjack.in_context?).to eq true
       end
-      expect(Lumberjack.context?).to eq false
+      expect(Lumberjack.in_context?).to eq false
     end
 
     it "should return the result of the context block" do


### PR DESCRIPTION
Use `in_context?` instead of `context?` since it conveys the meaning a little better.