### PR TITLE
Expose logger's default context manipulation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
   - `Lumberjack::LogEntry#tag`
   - `Lumberjack::LogEntry#tags`
   - `Lumberjack::LogEntry#nested_tags`
+  - `Lumberjack::Logger#set_progname`
   - `Lumberjack::Logger::Utils.flatten_tags`
   - `Lumberjack::Logger::Utils.expand_tags`
   - `Lumberjack::Logger::TagContext`

--- a/lib/lumberjack/forked_logger.rb
+++ b/lib/lumberjack/forked_logger.rb
@@ -6,12 +6,18 @@ module Lumberjack
 
     attr_reader :parent_logger
 
-    def initialize(logger)
+    def initialize(logger, context: nil)
       init_fiber_locals!
+
       @parent_logger = logger
-      @context = Context.new
-      @context.level ||= logger.level
-      @context.progname ||= logger.progname
+
+      if context
+        @context = context
+      else
+        @context = Context.new
+        @context.level ||= logger.level
+        @context.progname ||= logger.progname
+      end
     end
 
     def add_entry(severity, message, progname = nil, attributes = nil)

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -95,6 +95,19 @@ module Lumberjack
       @closed = false # TODO
     end
 
+    # Returns a forked logger that contains the default context for this logger. So any changes
+    # made to the context on that logger will be persisted in the default context on this logger.
+    #
+    # This can be used for setting default attributes that apply to all log entries.
+    #
+    # @return [ForkedLogger]
+    #
+    # @example
+    #   logger.global.tag!(host: Lumberjack::Utils.hostname)
+    def global
+      ForkedLogger.new(self, context: @context)
+    end
+
     # Get the logging device that is used to write log entries.
     #
     # @return [Lumberjack::Device] The logging device.
@@ -199,19 +212,21 @@ module Lumberjack
     # @param [String] value The program name to use.
     # @return [void]
     def set_progname(value, &block)
-      if block
-        with_progname(value, &block)
-      else
-        self.progname = value
+      Utils.deprecated(:set_progname, "Use with_progname or progname= instead.") do
+        if block
+          with_progname(value, &block)
+        else
+          self.progname = value
+        end
       end
     end
 
-    # Use tag! instead
+    # Use `global.tag!`` instead
     #
     # @return [void]
     # @deprecated Use {#tag!} instead.
     def tag_globally(tags)
-      Utils.deprecated(:tag_globally, "Use tag! instead.") do
+      Utils.deprecated(:tag_globally, "Use global.tag! instead.") do
         tag!(tags)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,6 @@ begin
 rescue LoadError
 end
 
-# Enable all warnings to protect against bad practices and deprecations.
-$VERBOSE = true
-
 require_relative "../lib/lumberjack"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Introduce a global method to allow manipulation of a logger's default context, enabling consistent attribute settings across log entries. Update related tests to verify functionality.