### PR TITLE
Add device to wrap loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Added `Lumberjack::Logger#untag!` and `Lumberjack::Logger#untag!` to remove global tags from a logger.
 - Added `Lumberjack::Logger#in_context?` as a replacement for `Lumberjack::Logger.in_tag_context?` and `Lumberjack.in_context?` as a replacement for `Lumberjack::Logger.context?`.
 - Added IO compatibility methods for logging. Calling `logger.write`, `logger.puts`, `logger.print`, or `logger.printf` will write log entries. The severity of the log entries can be set with `default_severity`.
+- Added `Lumberjack::Device::Logger` as a device that forwards entries to another Lumberjack logger.
 - Added `Lumberjack::Device::Test` class for use in testing logging functionality. This device will buffer log entries and has `match?` and `include?` methods that can be used for assertions in tests.
 - Added support for standard library `Logger::Formatter`. This is for compatibility with the standard library `Logger`. If a standard library logger is passed to `Lumberjack::Logger` as the formatter, it will override the template when writing to a stream. Tags are not available in the output when using a standard library formatter.
 - Classes can now define their own formatting in logs by implementing the `to_log_format` method. If an object responds to this method, it will be called in lieu of looking up the formatter by class. This allows a pattern of defining log formatting along with the code rather than in a an initializer.

--- a/lib/lumberjack/device.rb
+++ b/lib/lumberjack/device.rb
@@ -6,6 +6,7 @@ module Lumberjack
   class Device
     require_relative "device/writer"
     require_relative "device/logger_file"
+    require_relative "device/logger"
     require_relative "device/multi"
     require_relative "device/null"
     require_relative "device/test"

--- a/lib/lumberjack/device/logger.rb
+++ b/lib/lumberjack/device/logger.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Lumberjack
+  # Device that writes log entries to a Lumberjack logger. You can use
+  # this in combination with the Lumberjack::Device::Multi device to
+  # create a master logger that broadcasts to other loggers.
+  class Device::Logger < Device
+    attr_reader :logger
+
+    def initialize(logger)
+      raise ArgumentError.new("Logger must be a Lumberjack logger") unless logger.is_a?(Lumberjack::ContextLogger)
+
+      @logger = logger
+    end
+
+    def write(entry)
+      @logger.add_entry(entry.severity, entry.message, entry.progname, entry.attributes)
+    end
+  end
+end

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -312,6 +312,8 @@ module Lumberjack
         Device::Test.new(options)
       elsif device.is_a?(Device)
         device
+      elsif device.is_a?(ContextLogger)
+        Device::Logger.new(device)
       elsif device.respond_to?(:write) && !device.respond_to?(:path)
         Device::Writer.new(device, options)
       else

--- a/spec/lumberjack/device/logger_spec.rb
+++ b/spec/lumberjack/device/logger_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lumberjack::Device::Logger do
+  it "wraps another logger as a device" do
+    logger = Lumberjack::Logger.new(:test)
+    outer_logger = Lumberjack::Logger.new(Lumberjack::Device::Logger.new(logger), progname: "MyApp")
+    outer_logger.info("Test log message", foo: "bar")
+    expect(logger.device).to(
+      include(severity: :info, message: "Test log message", progname: "MyApp", attributes: {"foo" => "bar"})
+    )
+  end
+
+  it "automatically wraps a logger set as the device" do
+    logger = Lumberjack::Logger.new(:test)
+    outer_logger = Lumberjack::Logger.new(logger, progname: "MyApp")
+    outer_logger.info("Test log message", foo: "bar")
+    expect(logger.device).to(
+      include(severity: :info, message: "Test log message", progname: "MyApp", attributes: {"foo" => "bar"})
+    )
+  end
+end


### PR DESCRIPTION
- Added `Lumberjack::Device::Logger` as a device that forwards entries to another Lumberjack logger.
