### PR TITLE
Apply to_log_format consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ class User
     "User[id: #{id}, name: #{name}]"
   end
 end
+```
+
+Primitive classes (`String`, `Integer`, `Float`, `TrueClass`, `FalseClass`, `NilClass`, `BigDecimal`) will not use `to_log_format`.
 
 #### Attribute Formatters
 

--- a/lib/lumberjack/attribute_formatter.rb
+++ b/lib/lumberjack/attribute_formatter.rb
@@ -308,6 +308,10 @@ module Lumberjack
         value
       end
 
+      if formatted_value.is_a?(Formatter::TaggedMessage)
+        formatted_value = formatted_value.attributes
+      end
+
       if formatted_value.is_a?(Enumerable)
         skip_classes ||= []
         skip_classes << value.class if using_class_formatter

--- a/lib/lumberjack/entry_formatter.rb
+++ b/lib/lumberjack/entry_formatter.rb
@@ -163,11 +163,7 @@ module Lumberjack
     # @return [Array<Object, Hash>] A two-element array containing [formatted_message, formatted_attributes].
     def format(message, attributes)
       message = message.call if message.is_a?(Proc)
-      if message.respond_to?(:to_log_format) && message.method(:to_log_format).parameters.empty?
-        message = message.to_log_format
-      elsif message_formatter
-        message = message_formatter.format(message)
-      end
+      message = message_formatter.format(message) if message_formatter.respond_to?(:format)
 
       message_attributes = nil
       if message.is_a?(Formatter::TaggedMessage)

--- a/spec/lumberjack/attribute_formatter_spec.rb
+++ b/spec/lumberjack/attribute_formatter_spec.rb
@@ -123,4 +123,10 @@ RSpec.describe Lumberjack::AttributeFormatter do
     attribute_formatter = Lumberjack::AttributeFormatter.new
     expect(attribute_formatter.format(attributes).object_id).to eq attributes.object_id
   end
+
+  it "uses the attributes from a TaggedMessage" do
+    attribute_formatter = Lumberjack::AttributeFormatter.new
+    attribute_formatter.add("foo") { |val| Lumberjack::Formatter::TaggedMessage.new(val.upcase, "attr" => val) }
+    expect(attribute_formatter.format({"foo" => "bar"})).to eq({"foo" => {"attr" => "bar"}})
+  end
 end

--- a/spec/lumberjack/entry_formatter_spec.rb
+++ b/spec/lumberjack/entry_formatter_spec.rb
@@ -84,20 +84,6 @@ RSpec.describe Lumberjack::EntryFormatter do
       expect(attributes).to eq({"attribute" => "foobar", "foo" => "bar"})
     end
 
-    it "applies the to_log_format method instead of the registered formatter if it exists" do
-      obj = +"FooBar"
-      def obj.to_log_format
-        "Custom format for #{self}"
-      end
-
-      entry_formatter.add(String) { |s| "String: #{s}" }
-      message, _ = entry_formatter.format("foobar", {})
-      expect(message).to eq("String: foobar")
-
-      message, _ = entry_formatter.format(obj, {})
-      expect(message).to eq("Custom format for FooBar")
-    end
-
     it "applies the attribute formatter to the attributes" do
       entry_formatter.attributes { add("foo") { |obj| "Foo: #{obj}" } }
       message, attributes = entry_formatter.format("foobar", {"foo" => "bar"})

--- a/spec/lumberjack/formatter_spec.rb
+++ b/spec/lumberjack/formatter_spec.rb
@@ -116,6 +116,17 @@ RSpec.describe Lumberjack::Formatter do
     expect(formatter.format(:test)).to eq(:test)
   end
 
+  it "applies the to_log_format method if there is no registered formatter" do
+    obj = TestToLogFormat.new("test")
+    expect(formatter.format(obj)).to eq("LOG FORMAT: test")
+  end
+
+  it "overrides the to_log_format method if there is a registered formatter" do
+    formatter.add(TestToLogFormat) { |obj| obj.value.upcase }
+    obj = TestToLogFormat.new("test")
+    expect(formatter.format(obj)).to eq("TEST")
+  end
+
   describe "clear" do
     it "should clear all mappings" do
       expect(formatter.format(:test)).to eq(":test")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,3 +99,15 @@ class TestContextLogger
     @context
   end
 end
+
+class TestToLogFormat
+  attr_reader :value
+
+  def initialize(value)
+    @value = value
+  end
+
+  def to_log_format
+    "LOG FORMAT: #{@value}"
+  end
+end


### PR DESCRIPTION
- Apply `to_log_format` on both tags and message when a formatter is not defined.
- Handle case where TaggedMessage is returned in an attribute formatter by taking the attributes.