### PR TITLE
Restore Rails compatibility methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 
 ### Removed
 
-- Removed Rails integration code (`tagged`, `silence`, `log_at` methods on `Lumberjack::Logger`). Rails support is now moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem. **Breaking Change**
 - Removed deprecated unit of work id code. These have been replaced with tags. **Breaking Change**
 - Removed deprecated support for setting global tags with `Lumberjack::Logger#tag`. Now calling `tag` outside of a block or context will be ignored. Use `tag!` to set default tags on a logger. **Breaking Change**
 - Removed the devices that handled logging to files (`Lumberjack::Device::LogFile`, `Lumberjack::Device::RollingLogFile`, `Lumberjack::Device::DateRollingLogFile`, and `Lumberjack::Device::SizeRollingLogFile`) since file logging is now handled by the standard library `Logger::LogDevice` class. **Breaking Change**
@@ -71,6 +70,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
   - `Lumberjack::Logger::TagContext`
   - `Lumberjack::Logger::TagFormatter`
   - `Lumberjack::Logger::Tags`
+- Deprecated Rails compatibility methods on `Lumberjack::Logger` (`tagged`, `silence`, `log_at`). Rails support is now moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem.
 
 ## 1.4.0
 

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -89,6 +89,10 @@ module Lumberjack
       template: nil, message_formatter: nil, attribute_formatter: nil, **kwargs)
       init_fiber_locals!
 
+      if shift_age.is_a?(Hash)
+        raise ArgumentError.new("options must be passed as keyword arguments instead of a Hash")
+      end
+
       # Include standard args that affect devices with the optional kwargs which may
       # contain device specific options.
       device_options = kwargs.merge(shift_age: shift_age, shift_size: shift_size, binmode: binmode, shift_period_suffix: shift_period_suffix)
@@ -290,6 +294,47 @@ module Lumberjack
       Utils.deprecated(:remove_tag, "Use untag or untag! instead.") do
         attributes = current_context&.attributes
         AttributesHelper.new(attributes).delete(*tag_names) if attributes
+      end
+    end
+
+    # Minimal support for the ActiveSupport::TaggedLogging API. This functionality has been
+    # moved to the lumberjack_rails gem. Note that in the lumberjack_rails version tags will
+    # be appended to the "tags" attribute instead of the "tagged" attribute.
+    #
+    # @deprecated This implementation is deprecated. Install the lumberjack_rails gem for full support.
+    def tagged(*tags, &block)
+      deprecation_message = "Install the lumberjack_rails gem for full support of the tagged method."
+      Utils.deprecated(:tagged, deprecation_message) do
+        return self unless in_context?
+
+        current_tags = attributes["tagged"] || []
+        all_tags = current_tags + tags.flatten
+        tag("tagged" => all_tags, &block)
+        self
+      end
+    end
+
+    # Alias for with_level for compatibility with ActiveSupport loggers. This functionality
+    # has been moved to the lumberjack_rails gem.
+    #
+    # @see with_level
+    # @deprecated This implementation is deprecated. Install the lumberjack_rails gem for full support.
+    def log_at(level, &block)
+      deprecation_message = "Install the lumberjack_rails gem for full support of the log_at method."
+      Utils.deprecated(:log_at, deprecation_message) do
+        with_level(level, &block)
+      end
+    end
+
+    # Alias for with_level for compatibilty with ActiveSupport loggers. This functionality
+    # has been moved to the lumberjack_rails gem.
+    #
+    # @see with_level
+    # @deprecated This implementation is deprecated. Install the lumberjack_rails gem for full support.
+    def silence(level = Logger::ERROR, &block)
+      deprecation_message = "Install the lumberjack_rails gem for full support of the silence method."
+      Utils.deprecated(:silence, deprecation_message) do
+        with_level(level, &block)
       end
     end
 

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -517,4 +517,89 @@ RSpec.describe Lumberjack::Logger do
       end
     end
   end
+
+  describe "#tagged" do
+    let(:logger) { Lumberjack::Logger.new(:test) }
+
+    around do |example|
+      silence_deprecations do
+        example.run
+      end
+    end
+
+    it "does nothing if there is no context" do
+      expect(logger.tagged).to eq(logger)
+      expect(logger.tags).to be_empty
+    end
+
+    it "appends tags to the tags attribute in the current context" do
+      logger.context do
+        logger.tagged(:foo, :bar)
+        expect(logger.attributes["tagged"]).to eq([:foo, :bar])
+
+        logger.tagged(:baz)
+        expect(logger.attributes["tagged"]).to eq([:foo, :bar, :baz])
+
+        logger.context do
+          logger.tagged(:qux)
+          expect(logger.attributes["tagged"]).to eq([:foo, :bar, :baz, :qux])
+        end
+
+        expect(logger.attributes["tagged"]).to eq([:foo, :bar, :baz])
+      end
+    end
+
+    it "appends to the tags attribute inside a block" do
+      logger.tagged(:foo, :bar) do
+        expect(logger.attributes["tagged"]).to eq([:foo, :bar])
+
+        logger.tagged(:baz) do
+          expect(logger.attributes["tagged"]).to eq([:foo, :bar, :baz])
+        end
+
+        expect(logger.attributes["tagged"]).to eq([:foo, :bar])
+      end
+    end
+  end
+
+  describe "#log_at" do
+    let(:logger) { Lumberjack::Logger.new(:test) }
+
+    around do |example|
+      silence_deprecations do
+        example.run
+      end
+    end
+
+    it "changes the log level temporarily" do
+      logger.log_at(:info) do
+        expect(logger.level).to eq(Logger::INFO)
+      end
+      expect(logger.level).to eq(Logger::DEBUG)
+    end
+  end
+
+  describe "#silence" do
+    let(:logger) { Lumberjack::Logger.new(:test) }
+
+    around do |example|
+      silence_deprecations do
+        example.run
+      end
+    end
+
+    it "temporarily suppresses logging" do
+      logger.silence do
+        expect(logger.level).to eq(Logger::ERROR)
+      end
+      expect(logger.level).to eq(Logger::DEBUG)
+    end
+
+    it "can specify the log level" do
+      logger.silence(Logger::WARN) do
+        expect(logger.level).to eq(Logger::WARN)
+      end
+      expect(logger.level).to eq(Logger::DEBUG)
+    end
+  end
 end


### PR DESCRIPTION
Mark Rails compatibility methods as deprecated rather than removing entirely.