### PR TITLE
Add device registry for custom devices to register with Lumberjack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Added `Lumberjack.build_formatter` as a helper method for building entry formatters.
 - Templates can now be use a left padded severity label with the option `pad_severity: true`. This will left pad the severity strings to five characters so that they can all be aligned in the log output.
 - Added `Lumberjack::Formatter::Tags` for formatting attributes as "tags" in the logs. Arrays of values will be formatted as "[val1] [val2]" and hashes will be formatted as "[key1=value1] [key2=value2]".
+- Added `Lumberjack::DeviceRegistry` as a means for other devices to be associated with a symbol that can then be passed to the constructor when creating a logger with that device rather than having to instantiate the device first.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -396,17 +396,14 @@ logger = Lumberjack::Logger.new("/var/log/app.log", 'daily')
 
 ##### Multi Device
 
-The `Multi` device broadcasts log entries to multiple devices simultaneously:
+The `Multi` device broadcasts log entries to multiple devices simultaneously. You can
+instantiate a multi device by passing in an array of values.
 
 ```ruby
-# Log to both file and console
-file_device = Lumberjack::Device::Writer.new("/var/log/app.log")
-console_device = Lumberjack::Device::Writer.new(STDOUT, template: ":message")
+# Log to both file and STDOUT using the same template.
+logger = Lumberjack::Logger.new(["/var/log/app.log", $stdout], template: ":severity :message")
 
-multi_device = Lumberjack::Device::Multi.new(file_device, console_device)
-logger = Lumberjack::Logger.new(multi_device)
-
-logger.info("Application started")  # Appears in both file AND console
+logger.info("Application started")  # Appears in both file AND STDOUT
 ```
 
 ##### LoggerWrapper Device
@@ -477,6 +474,16 @@ There are separate gems implementing custom devices for different use cases:
 - [`lumberjack_capture_device`](https://github.com/bdurand/lumberjack_capture_device) - Device designed for capturing logs in tests to make assertions easier
 - [`lumberjack_syslog_device`](https://github.com/bdurand/lumberjack_syslog_device) - Device for logging to a syslog server
 - [`lumberjack_redis_device`](https://github.com/bdurand/lumberjack_redis_device) - Device for logging to a Redis database
+
+You can register a custom device with Lumberjack using the device registry. This associates the device with the device class and can make using the device easier to setup since the user can just pass the symbol and options when instantiating the Logger rather than having to instantiate the device separately.
+
+```ruby
+  Lumberjack::Device.register(:my_device, MyDevice)
+
+  # Now logger can be instantiated with the name and all options will be passed to
+  # the MyDevice constructor.
+  logger = Lumberjack::Logger.new(:my_device, autoflush: true)
+```
 
 ### Testing Utilities
 

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -42,6 +42,7 @@ module Lumberjack
   require_relative "lumberjack/io_compatibility"
   require_relative "lumberjack/log_entry"
   require_relative "lumberjack/log_entry_matcher"
+  require_relative "lumberjack/device_registry"
   require_relative "lumberjack/device"
   require_relative "lumberjack/entry_formatter"
   require_relative "lumberjack/formatter"

--- a/lib/lumberjack/device.rb
+++ b/lib/lumberjack/device.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "device_registry"
+
 module Lumberjack
   # Abstract base class defining the interface for logging output devices.
   # Devices are responsible for the final output of log entries to various

--- a/lib/lumberjack/device/multi.rb
+++ b/lib/lumberjack/device/multi.rb
@@ -20,6 +20,8 @@ module Lumberjack
   #   console_device = Lumberjack::Device::Writer.new(STDOUT, template: ":message")
   #   multi_device = Lumberjack::Device::Multi.new(file_device, console_device)
   class Device::Multi < Device
+    attr_reader :devices
+
     # Initialize a new Multi device with the specified target devices. The device
     # accepts multiple devices either as individual arguments or as arrays,
     # automatically flattening nested arrays for convenient configuration.
@@ -42,7 +44,7 @@ module Lumberjack
     # @param entry [Lumberjack::LogEntry] The log entry to broadcast to all devices
     # @return [void]
     def write(entry)
-      @devices.each do |device|
+      devices.each do |device|
         device.write(entry)
       end
     end
@@ -53,7 +55,7 @@ module Lumberjack
     #
     # @return [void]
     def flush
-      @devices.each do |device|
+      devices.each do |device|
         device.flush
       end
     end
@@ -64,7 +66,7 @@ module Lumberjack
     #
     # @return [void]
     def close
-      @devices.each do |device|
+      devices.each do |device|
         device.close
       end
     end
@@ -77,7 +79,7 @@ module Lumberjack
     #   to each device's reopen method
     # @return [void]
     def reopen(logdev = nil)
-      @devices.each do |device|
+      devices.each do |device|
         device.reopen(logdev = nil)
       end
     end
@@ -89,7 +91,7 @@ module Lumberjack
     # @return [String, nil] The datetime format string from the first device
     #   that has one configured, or nil if no devices have a format set
     def datetime_format
-      @devices.detect(&:datetime_format).datetime_format
+      devices.detect(&:datetime_format).datetime_format
     end
 
     # Set the datetime format on all configured devices that support it.
@@ -99,7 +101,7 @@ module Lumberjack
     # @param format [String] The datetime format string to apply to all devices
     # @return [void]
     def datetime_format=(format)
-      @devices.each do |device|
+      devices.each do |device|
         device.datetime_format = format
       end
     end

--- a/lib/lumberjack/device/null.rb
+++ b/lib/lumberjack/device/null.rb
@@ -18,6 +18,8 @@ module Lumberjack
   #   logger = Lumberjack::Logger.new(:null)
   #   logger.error("This error is also discarded")
   class Device::Null < Device
+    DeviceRegistry.add(:null, self)
+
     def initialize(*args)
     end
 

--- a/lib/lumberjack/device/test.rb
+++ b/lib/lumberjack/device/test.rb
@@ -53,6 +53,8 @@ module Lumberjack
   #
   # @see LogEntryMatcher
   class Device::Test < Device
+    DeviceRegistry.add(:test, self)
+
     # @!attribute [rw] max_entries
     #   @return [Integer] The maximum number of entries to retain in the buffer
     attr_accessor :max_entries

--- a/lib/lumberjack/device_registry.rb
+++ b/lib/lumberjack/device_registry.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Lumberjack
+  # The device registry is used for setting up names to represent Device classes. It is used
+  # in the constructor for Lumberjack::Logger and allows passing in a symbol to reference a
+  # device.
+  #
+  # Devices must have a constructor that accepts the options hash as its sole argument in order
+  # to use the device registry.
+  #
+  # @example
+  #
+  #   Lumberjack::Device.register(:my_device, MyDevice)
+  #   logger = Lumberjack::Logger.new(:my_device)
+  module DeviceRegistry
+    @device_registry = {}
+
+    class << self
+      # Register a device name. Device names can be used to associate a symbol with a device
+      # class. The symbol can then be passed to Logger as the device argument.
+      #
+      # Registered devices must take only one argument and that is the options hash for the
+      # device options.
+      #
+      # @param name [Symbol] The name of the device
+      # @param klass [Class] The device class to register
+      # @return [void]
+      def add(name, klass)
+        raise ArgumentError.new("name must be a symbol") unless name.is_a?(Symbol)
+
+        @device_registry[name] = klass
+      end
+
+      # Remove a device from the registry.
+      #
+      # @param name [Symbol] The name of the device to remove
+      # @return [void]
+      def remove(name)
+        @device_registry.delete(name)
+      end
+
+      # Instantiate a new device with the specified options from the device registry.
+      #
+      # @param name [Symbol] The name of the device
+      # @param options [Hash] The device options
+      # @return [Lumberjack::Device]
+      def new_device(name, options)
+        klass = device_class(name)
+        raise ArgumentError.new("#{name.inspect} is not registered as a device name") unless klass
+
+        klass.new(options)
+      end
+
+      # Retrieve the class registered with the given name or nil if the name is not defined.
+      #
+      # @param name [Symbol] The name of the device
+      # @return [Class, nil] The registered device class or nil if not found
+      def device_class(name)
+        @device_registry[name]
+      end
+
+      # Return the map of registered device class names.
+      #
+      # @return [Hash]
+      def registered_devices
+        @device_registry.dup
+      end
+    end
+  end
+end

--- a/lib/lumberjack/device_registry.rb
+++ b/lib/lumberjack/device_registry.rb
@@ -46,7 +46,10 @@ module Lumberjack
       # @return [Lumberjack::Device]
       def new_device(name, options)
         klass = device_class(name)
-        raise ArgumentError.new("#{name.inspect} is not registered as a device name") unless klass
+        unless klass
+          valid_names = @device_registry.keys.map(&:inspect).join(", ")
+          raise ArgumentError.new("#{name.inspect} is not registered as a device name; valid names are: #{valid_names}")
+        end
 
         klass.new(options)
       end

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -397,14 +397,16 @@ module Lumberjack
     def open_device(device, options) # :nodoc:
       device = device.to_s if device.is_a?(Pathname)
 
-      if device.nil? || device == :null
+      if device.nil?
         Device::Null.new
-      elsif device == :test
-        Device::Test.new(options)
       elsif device.is_a?(Device)
         device
+      elsif device.is_a?(Symbol)
+        DeviceRegistry.new_device(device, options)
       elsif device.is_a?(ContextLogger)
         Device::LoggerWrapper.new(device)
+      elsif device.is_a?(Array)
+        Device::Multi.new(device.collect { |d| open_device(d, options) })
       elsif io_but_not_file_stream?(device)
         Device::Writer.new(device, options)
       else

--- a/spec/lumberjack/device_registry_spec.rb
+++ b/spec/lumberjack/device_registry_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lumberjack::DeviceRegistry do
+  it "has :null and :test registered by default" do
+    expect(Lumberjack::DeviceRegistry.registered_devices).to eq({
+      null: Lumberjack::Device::Null,
+      test: Lumberjack::Device::Test
+    })
+  end
+
+  it "can add new devices to the registry" do
+    Lumberjack::DeviceRegistry.add(:foobar, Object)
+    expect(Lumberjack::DeviceRegistry.device_class(:foobar)).to eq Object
+    expect(Lumberjack::DeviceRegistry.device_class(:other)).to be_nil
+  ensure
+    Lumberjack::DeviceRegistry.remove(:foobar)
+  end
+
+  it "can instantiate a device by name and options" do
+    device = Lumberjack::DeviceRegistry.new_device(:test, max_entries: 15)
+    expect(device).to be_a(Lumberjack::Device::Test)
+    expect(device.max_entries).to eq 15
+  end
+end

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe Lumberjack::Logger do
       expect(logger.device.class).to eq(Lumberjack::Device::Test)
     end
 
+    it "should create a multi device if the stream is an array" do
+      stream_1 = StringIO.new
+      stream_2 = StringIO.new
+      logger = Lumberjack::Logger.new([stream_1, stream_2])
+      device = logger.device
+      expect(device).to be_a(Lumberjack::Device::Multi)
+      expect(device.devices.collect(&:dev)).to eq [stream_1, stream_2]
+    end
+
     it "should set the level with a numeric" do
       logger = Lumberjack::Logger.new(:null, level: Logger::WARN)
       expect(logger.level).to eq(Logger::WARN)


### PR DESCRIPTION
- Added `Lumberjack::DeviceRegistry` as a means for other devices to be associated with a symbol that can then be passed to the constructor when creating a logger with that device rather than having to instantiate the device first.
