### PR TITLE
Restore support for tagged method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Logging to files will now use the standard library `Logger::LogDevice` class for file output and rolling.
 - The `Lumberjack::Device::Writer` class now takes an `autoflush` option. Setting it to false will disable synchronous I/O.
 - `Lumberjack#tag` can now be called with a block to set up a new context.
+- The `tagged` method is now adds tags to the "tags" attribute instead of the "tagged" attribute. **Breaking Change**
 
 ### Removed
 
@@ -70,7 +71,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
   - `Lumberjack::Logger::TagContext`
   - `Lumberjack::Logger::TagFormatter`
   - `Lumberjack::Logger::Tags`
-- Deprecated Rails compatibility methods on `Lumberjack::Logger` (`tagged`, `silence`, `log_at`). Rails support is now moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem.
+- Deprecated Rails compatibility methods on `Lumberjack::Logger` (`silence`, `log_at`). Rails support is now moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem.
 
 ## 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ logger.debug("Processing data",
 )
 ```
 
-#### Using the Tag Method
+#### Adding attributes to the logger
 
-The `tag` method can be used to add attributes to the current log [context](#context-blocks). The attributes will be included in all log entries for that context.
+Attributes added to the logger will be included in all log entries.
+
+Use the  `tag` method to tag the the current context with attributes. The attributes will be included in all log entries within that context.
 
 ```ruby
 logger.context do
@@ -141,6 +143,19 @@ Attributes use dot notation for nested structures, so there is no difference bet
 ```ruby
 logger.info("User signed in", user: {id: 123})
 logger.info("User signed in", "user.id" => 123)
+```
+
+#### Using the tagged method
+
+A common practice is to add an array of tags to log entries. The `tagged` method can be used to append tags to the current context. Tags are stored in the "tags" attribute. Like the `tag` method, this method can be called with a block to create a new context or without a block to update the current context.
+
+```ruby
+logger.tagged("api", "v1") do
+  logger.info("API request started") # Includes tags: ["api", "v1"]
+
+  logger.tagged("users")
+  logger.info("Processing user data") # Includes tags: ["api", "v1", "users"]
+end
 ```
 
 ### Context Isolation

--- a/lib/lumberjack/context_logger.rb
+++ b/lib/lumberjack/context_logger.rb
@@ -346,6 +346,24 @@ module Lumberjack
       nil
     end
 
+    # Add tags the logger "tags" attribute. This method supports a common pattern of adding
+    # an array of tags to log entries. Calling this method will append the specified tags to any
+    # existing values on the "tags" attribute. If this is called with a block, it will create a
+    # new context for the block and add the tags to that context. Otherwise it will add the tags
+    # to the current context. If there is no current context, then nothing will happen.
+    #
+    # @param tags [Array<String, Symbol, Hash>] The tags to add.
+    # @return [Lumberjack::Logger] Returns self so calls can be chained.
+    def tagged(*tags, &block)
+      return self unless block || in_context?
+
+      current_tags = attributes["tags"] || []
+      current_tags = [current_tags] unless current_tags.is_a?(Array)
+      new_tags = current_tags + tags.flatten
+
+      tag(tags: new_tags, &block)
+    end
+
     # Set up a context block for the logger. All attributes added within the block will be cleared when
     # the block exits.
     #

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -297,23 +297,6 @@ module Lumberjack
       end
     end
 
-    # Minimal support for the ActiveSupport::TaggedLogging API. This functionality has been
-    # moved to the lumberjack_rails gem. Note that in the lumberjack_rails version tags will
-    # be appended to the "tags" attribute instead of the "tagged" attribute.
-    #
-    # @deprecated This implementation is deprecated. Install the lumberjack_rails gem for full support.
-    def tagged(*tags, &block)
-      deprecation_message = "Install the lumberjack_rails gem for full support of the tagged method."
-      Utils.deprecated(:tagged, deprecation_message) do
-        return self unless in_context?
-
-        current_tags = attributes["tagged"] || []
-        all_tags = current_tags + tags.flatten
-        tag("tagged" => all_tags, &block)
-        self
-      end
-    end
-
     # Alias for with_level for compatibility with ActiveSupport loggers. This functionality
     # has been moved to the lumberjack_rails gem.
     #

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -518,50 +518,6 @@ RSpec.describe Lumberjack::Logger do
     end
   end
 
-  describe "#tagged" do
-    let(:logger) { Lumberjack::Logger.new(:test) }
-
-    around do |example|
-      silence_deprecations do
-        example.run
-      end
-    end
-
-    it "does nothing if there is no context" do
-      expect(logger.tagged).to eq(logger)
-      expect(logger.tags).to be_empty
-    end
-
-    it "appends tags to the tags attribute in the current context" do
-      logger.context do
-        logger.tagged(:foo, :bar)
-        expect(logger.attributes["tagged"]).to eq([:foo, :bar])
-
-        logger.tagged(:baz)
-        expect(logger.attributes["tagged"]).to eq([:foo, :bar, :baz])
-
-        logger.context do
-          logger.tagged(:qux)
-          expect(logger.attributes["tagged"]).to eq([:foo, :bar, :baz, :qux])
-        end
-
-        expect(logger.attributes["tagged"]).to eq([:foo, :bar, :baz])
-      end
-    end
-
-    it "appends to the tags attribute inside a block" do
-      logger.tagged(:foo, :bar) do
-        expect(logger.attributes["tagged"]).to eq([:foo, :bar])
-
-        logger.tagged(:baz) do
-          expect(logger.attributes["tagged"]).to eq([:foo, :bar, :baz])
-        end
-
-        expect(logger.attributes["tagged"]).to eq([:foo, :bar])
-      end
-    end
-  end
-
   describe "#log_at" do
     let(:logger) { Lumberjack::Logger.new(:test) }
 


### PR DESCRIPTION
- The `tagged` method is now adds tags to the "tags" attribute instead of the "tagged" attribute. **Breaking Change**
