### PR TITLE
Rename tagged and untagged methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Templates can now be use a left padded severity label with the option `pad_severity: true`. This will left pad the severity strings to five characters so that they can all be aligned in the log output.
 - Added `Lumberjack::Formatter::Tags` for formatting attributes as "tags" in the logs. Arrays of values will be formatted as "[val1] [val2]" and hashes will be formatted as "[key1=value1] [key2=value2]".
 - Added `Lumberjack::DeviceRegistry` as a means for other devices to be associated with a symbol that can then be passed to the constructor when creating a logger with that device rather than having to instantiate the device first.
+- Added `Lumberjack::Logger#clear_attributes` to remove all attributes from the logger.
 
 ### Changed
 
@@ -43,7 +44,6 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Logging to files will now use the standard library `Logger::LogDevice` class for file output and rolling.
 - The `Lumberjack::Device::Writer` class now takes an `autoflush` option. Setting it to false will disable synchronous I/O.
 - `Lumberjack#tag` can now be called with a block to set up a new context.
-- The `tagged` method is now adds tags to the "tags" attribute instead of the "tagged" attribute. **Breaking Change**
 
 ### Removed
 
@@ -59,6 +59,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
   - `Lumberjack.context_tags`
   - `Lumberjack::Logger#tags`
   - `Lumberjack::Logger#tag_value`
+  - `Lumberjack::Logger#untagged`
   - `Lumberjack::Logger#tag_formatter`
   - `Lumberjack::Logger#in_tag_context?`
   - `Lumberjack::Logger#tag_globally`
@@ -72,7 +73,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
   - `Lumberjack::Logger::TagContext`
   - `Lumberjack::Logger::TagFormatter`
   - `Lumberjack::Logger::Tags`
-- Deprecated Rails compatibility methods on `Lumberjack::Logger` (`silence`, `log_at`). Rails support is now moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem.
+- Deprecated Rails compatibility methods on `Lumberjack::Logger` (`tagged`, `silence`, `log_at`). Rails support is now moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem.
 
 ## 1.4.0
 

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -297,6 +297,29 @@ module Lumberjack
       end
     end
 
+    # Alias for append_to(:tagged) for compatibility with ActiveSupport support in Lumberjack 1.x.
+    # This functionality has been moved to the lumberjack_rails gem. Note that in that gem the
+    # tags are added to the :tags attribute instead of the :tagged attribute.
+    #
+    # @see append_to
+    # @deprecated This implementation is deprecated. Install the lumberjack_rails gem for full support.
+    def tagged(*tags, &block)
+      deprecation_message = "Install the lumberjack_rails gem for full support of the tagged method."
+      Utils.deprecated(:tagged, deprecation_message) do
+        append_to(:tagged, *tags, &block)
+      end
+    end
+
+    # Alias for clear_attributes.
+    #
+    # @see clear_attributes
+    # @deprecated Use clear_attributes instead.
+    def untagged(&block)
+      Utils.deprecated(:untagged, "Use clear_attributes instead.") do
+        clear_attributes(&block)
+      end
+    end
+
     # Alias for with_level for compatibility with ActiveSupport loggers. This functionality
     # has been moved to the lumberjack_rails gem.
     #

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -451,22 +451,22 @@ RSpec.describe Lumberjack::ContextLogger do
     end
   end
 
-  describe "#tagged" do
+  describe "#append_to" do
     it "does nothing if there is no context" do
-      expect(logger.tagged(:foo)).to eq(logger)
+      expect(logger.append_to(:tags, :foo)).to eq(logger)
       expect(logger.attributes).to be_empty
     end
 
     it "appends tags to the tags attribute in the current context" do
       logger.context do
-        logger.tagged(:foo, :bar)
+        logger.append_to(:tags, :foo, :bar)
         expect(logger.attributes["tags"]).to eq([:foo, :bar])
 
-        logger.tagged(:baz)
+        logger.append_to(:tags, [:baz])
         expect(logger.attributes["tags"]).to eq([:foo, :bar, :baz])
 
         logger.context do
-          logger.tagged(:qux)
+          logger.append_to(:tags, :qux)
           expect(logger.attributes["tags"]).to eq([:foo, :bar, :baz, :qux])
         end
 
@@ -475,10 +475,10 @@ RSpec.describe Lumberjack::ContextLogger do
     end
 
     it "appends to the tags attribute inside a block" do
-      logger.tagged(:foo, :bar) do
+      logger.append_to(:tags, [:foo, :bar]) do
         expect(logger.attributes["tags"]).to eq([:foo, :bar])
 
-        logger.tagged(:baz) do
+        logger.append_to(:tags, [:baz]) do
           expect(logger.attributes["tags"]).to eq([:foo, :bar, :baz])
         end
 
@@ -488,24 +488,24 @@ RSpec.describe Lumberjack::ContextLogger do
 
     it "returns the logger instance when called without a block" do
       logger.context do
-        expect(logger.tagged(:foo)).to eq(logger)
+        expect(logger.append_to(:tags, [:foo])).to eq(logger)
       end
     end
 
     it "returns the result of the block" do
-      result = logger.tagged(:foo) { :foobar }
+      result = logger.append_to(:tags, [:foo]) { :foobar }
       expect(result).to eq(:foobar)
     end
   end
 
-  describe "#untagged" do
+  describe "#clear_attributes" do
     it "removes all attributes from the current, default, and global contexts for the duration of the block" do
       Lumberjack.tag(foo: "bar") do
         logger_with_default_context.tag!(baz: "qux")
         logger_with_default_context.tag(bip: "bap") do
           expect(logger_with_default_context.attributes.length).to eq(3)
 
-          logger_with_default_context.untagged do
+          logger_with_default_context.clear_attributes do
             expect(logger_with_default_context.attributes).to be_empty
 
             logger_with_default_context.tag(moo: "mip") do
@@ -517,7 +517,7 @@ RSpec.describe Lumberjack::ContextLogger do
     end
 
     it "returns the result of the block" do
-      result = logger.untagged { :foobar }
+      result = logger.clear_attributes { :foobar }
       expect(result).to eq(:foobar)
     end
   end

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -527,6 +527,42 @@ RSpec.describe Lumberjack::Logger do
     end
   end
 
+  describe "#tagged" do
+    let(:logger) { Lumberjack::Logger.new(:test) }
+
+    around do |example|
+      silence_deprecations do
+        example.run
+      end
+    end
+
+    it "adds tags to the tagged attribute" do
+      logger.tagged("foo", "bar") do
+        expect(logger.attributes).to eq({"tagged" => ["foo", "bar"]})
+        logger.tagged("baz")
+        expect(logger.attributes).to eq({"tagged" => ["foo", "bar", "baz"]})
+      end
+    end
+  end
+
+  describe "#untagged" do
+    let(:logger) { Lumberjack::Logger.new(:test) }
+
+    around do |example|
+      silence_deprecations do
+        example.run
+      end
+    end
+
+    it "removes tags from the tagged attribute" do
+      logger.tag(foo: "bar") do
+        logger.untagged do
+          expect(logger.attributes).to be_empty
+        end
+      end
+    end
+  end
+
   describe "#log_at" do
     let(:logger) { Lumberjack::Logger.new(:test) }
 


### PR DESCRIPTION
Rename tagged to append_to and untagged to clear_attributes to make the method names more in line with "attributes" instead of "tags".