### PR TITLE
Make formatters easier to reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Added `Lumberjack::ForkedLogger` which is a wrapper around a logger with a separate context. A local logger has a parent logger which it will write it's log entries through. It will inherit the level, progname, and tags from a parent logger, but has its own local context isolated from the parent logger. You can change the level, progname, and add tags on the local logger without impacting the parent logger. Local loggers can be gotten from the current logger by calling `Lumberjack::Logger#fork`.
 - Added `Lumberjack::Utils.current_line` as a helper method for getting the current line of code.
 - Added `Lumberjack.build_formatter` as a helper method for building entry formatters.
+- Added merge method on formatters to allow merging in formats from other formatters.
 - Templates can now be use a left padded severity label with the option `pad_severity: true`. This will left pad the severity strings to five characters so that they can all be aligned in the log output.
 - Added `Lumberjack::Formatter::Tags` for formatting attributes as "tags" in the logs. Arrays of values will be formatted as "[val1] [val2]" and hashes will be formatted as "[key1=value1] [key2=value2]".
-- Added `Lumberjack::DeviceRegistry` as a means for other devices to be associated with a symbol that can then be passed to the constructor when creating a logger with that device rather than having to instantiate the device first.
+- Added `Lumberjack::FormatterRegistry` as a means of associating formatters with a symbol. Symbols can be used when adding class and attribute formatters. This extends the behavior previously limited to the built in formatters so that users can define their own formatters and register them for use.
+- Added `Lumberjack::DeviceRegistry` as a means for associating devices with a symbol. Symbols can then be passed to the constructor when creating a logger and the logger will take care of instantiating the device.
 - Added `Lumberjack::Logger#clear_attributes` to remove all attributes from the logger.
 
 ### Changed
@@ -40,6 +42,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - `LumberJack::Logger#context` now yields a `Lumberjack::Context` rather than a `Lumberjack::TagContext`. It must be called with a block and can no longer be used to return the current context. `Lumberjack#context` must also now be called with a block. **Breaking Change**
 - `Lumberjack::TagContext` has been renamed to `Lumberjack::AttributesHelper`.
 - `Lumberjack::TagFormatter` has been renamed to `Lumberjack::AttributeFormatter`.
+- `Lumberjack::Formatter` no longer includes any default formats. You can still get the default formatter with `Lumberjack::Formatter.default`. This formatter will still be used when instantiating a logger without specifying a formatter. You can use the new `merge` method to merge in the default formats from this formatter. The `empty` method has been deprecated since it is no longer needed. **Breaking Change**
 - `Lumberjack::Logger#add_entry` does not check the logger level and will add the entry regardless of the severity. This method is an internal API method and is now documented as such.
 - Logging to files will now use the standard library `Logger::LogDevice` class for file output and rolling.
 - The `Lumberjack::Device::Writer` class now takes an `autoflush` option. Setting it to false will disable synchronous I/O.
@@ -51,6 +54,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Removed deprecated support for setting global tags with `Lumberjack::Logger#tag`. Now calling `tag` outside of a block or context will be ignored. Use `tag!` to set default tags on a logger. **Breaking Change**
 - Removed the devices that handled logging to files (`Lumberjack::Device::LogFile`, `Lumberjack::Device::RollingLogFile`, `Lumberjack::Device::DateRollingLogFile`, and `Lumberjack::Device::SizeRollingLogFile`) since file logging is now handled by the standard library `Logger::LogDevice` class. **Breaking Change**
 - Removed internal buffer from the `Lumberjack::Device::Writer` class. This functionality was more useful in the days of slower I/O operations when logs were written to spinning hard disks. The functionality is no longer as useful and is not worth the overhead. The `Lumberjack::Logger.last_flushed_at` method has also been removed.
+- Formatters can no longer be passed as a class name in `Lumberjack::Formatter.add`. **Breaking Change**
 - Removed support for Ruby versions < 2.7.
 
 ### Deprecated
@@ -59,21 +63,24 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
   - `Lumberjack.context_tags`
   - `Lumberjack::Logger#tags`
   - `Lumberjack::Logger#tag_value`
+  - `Lumberjack::Logger#tagged`
+  - `Lumberjack::Logger#silence`
+  - `Lumberjack::Logger#log_at`
   - `Lumberjack::Logger#untagged`
   - `Lumberjack::Logger#tag_formatter`
   - `Lumberjack::Logger#in_tag_context?`
   - `Lumberjack::Logger#tag_globally`
   - `Lumberjack::Logger#remove_tag`
+  - `Lumberjack::Logger#set_progname`
   - `Lumberjack::LogEntry#tag`
   - `Lumberjack::LogEntry#tags`
   - `Lumberjack::LogEntry#nested_tags`
-  - `Lumberjack::Logger#set_progname`
   - `Lumberjack::Logger::Utils.flatten_tags`
   - `Lumberjack::Logger::Utils.expand_tags`
   - `Lumberjack::Logger::TagContext`
   - `Lumberjack::Logger::TagFormatter`
   - `Lumberjack::Logger::Tags`
-- Deprecated Rails compatibility methods on `Lumberjack::Logger` (`tagged`, `silence`, `log_at`). Rails support is now moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem.
+- The Rails compatibility methods on `Lumberjack::Logger` (`tagged`, `silence`, `log_at`) have been moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem. Installing that gem will restore these methods in a non-deprecated form.
 
 ## 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -386,6 +386,24 @@ end
 logger = Lumberjack::Logger.new(STDOUT, formatter: entry_formatter)
 ```
 
+#### Merging Formatters
+
+You can merge other formatters into your formatter with the `merge` method. Doing so will copy all of the format definitions.
+
+```ruby
+# Translate the duration tag to microseconds.
+duration_formatter = Lumberjack::EntryFormatter.build do
+  attributes do
+    add_attribute(:duration) { |seconds| (seconds.to_f * 1_000_000).round }
+  end
+end
+
+formatter = Lumberjack::EntryFormatter.build do
+  # Adds the duration attribute formatter
+  merge(duration_formatter)
+end
+```
+
 ### Output Devices
 
 Output devices control where and how log entries are written. Lumberjack provides a variety of built-in devices that can write to files, streams, multiple destinations, or serve special purposes like testing. All devices implement a common interface, making them interchangeable.

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -45,6 +45,7 @@ module Lumberjack
   require_relative "lumberjack/device_registry"
   require_relative "lumberjack/device"
   require_relative "lumberjack/entry_formatter"
+  require_relative "lumberjack/formatter_registry"
   require_relative "lumberjack/formatter"
   require_relative "lumberjack/forked_logger"
   require_relative "lumberjack/logger"

--- a/lib/lumberjack/device_registry.rb
+++ b/lib/lumberjack/device_registry.rb
@@ -13,7 +13,7 @@ module Lumberjack
   #   Lumberjack::Device.register(:my_device, MyDevice)
   #   logger = Lumberjack::Logger.new(:my_device)
   module DeviceRegistry
-    @device_registry = {}
+    @registry = {}
 
     class << self
       # Register a device name. Device names can be used to associate a symbol with a device
@@ -28,7 +28,7 @@ module Lumberjack
       def add(name, klass)
         raise ArgumentError.new("name must be a symbol") unless name.is_a?(Symbol)
 
-        @device_registry[name] = klass
+        @registry[name] = klass
       end
 
       # Remove a device from the registry.
@@ -36,7 +36,15 @@ module Lumberjack
       # @param name [Symbol] The name of the device to remove
       # @return [void]
       def remove(name)
-        @device_registry.delete(name)
+        @registry.delete(name)
+      end
+
+      # Check if a device is registered.
+      #
+      # @param name [Symbol] The name of the device
+      # @return [Boolean] True if the device is registered, false otherwise
+      def registered?(name)
+        @registry.include?(name)
       end
 
       # Instantiate a new device with the specified options from the device registry.
@@ -47,7 +55,7 @@ module Lumberjack
       def new_device(name, options)
         klass = device_class(name)
         unless klass
-          valid_names = @device_registry.keys.map(&:inspect).join(", ")
+          valid_names = @registry.keys.map(&:inspect).join(", ")
           raise ArgumentError.new("#{name.inspect} is not registered as a device name; valid names are: #{valid_names}")
         end
 
@@ -59,14 +67,14 @@ module Lumberjack
       # @param name [Symbol] The name of the device
       # @return [Class, nil] The registered device class or nil if not found
       def device_class(name)
-        @device_registry[name]
+        @registry[name]
       end
 
       # Return the map of registered device class names.
       #
       # @return [Hash]
       def registered_devices
-        @device_registry.dup
+        @registry.dup
       end
     end
   end

--- a/lib/lumberjack/entry_formatter.rb
+++ b/lib/lumberjack/entry_formatter.rb
@@ -87,10 +87,10 @@ module Lumberjack
     # @param attribute_formatter [Lumberjack::AttributeFormatter, nil] The attribute formatter to use.
     #   If nil, no attribute formatting will be performed unless configured later.
     def initialize(message_formatter: nil, attribute_formatter: nil)
-      if message_formatter.nil? || message_formatter == :default
+      if message_formatter == :default
+        message_formatter = Lumberjack::Formatter.default
+      elsif message_formatter.nil?
         message_formatter = Lumberjack::Formatter.new
-      elsif message_formatter == :none
-        message_formatter = Lumberjack::Formatter.empty
       end
 
       @message_formatter = message_formatter
@@ -151,6 +151,24 @@ module Lumberjack
     def attributes(&block)
       @attribute_formatter ||= Lumberjack::AttributeFormatter.new
       attribute_formatter.instance_exec(&block) if block
+      self
+    end
+
+    # Extend this formatter by merging the formats defined in the provided formatter into this one.
+    #
+    # @param formatter [Lumberjack::EntryFormatter] The formatter to merge.
+    # @return [self] Returns self for method chaining.
+    def merge(formatter)
+      unless formatter.is_a?(Lumberjack::EntryFormatter)
+        raise ArgumentError.new("formatter must be a Lumberjack::EntryFormatter")
+      end
+
+      @message_formatter ||= Lumberjack::Formatter.new
+      @message_formatter.merge(formatter.message_formatter)
+
+      @attribute_formatter ||= Lumberjack::AttributeFormatter.new
+      @attribute_formatter.merge(formatter.attribute_formatter)
+
       self
     end
 

--- a/lib/lumberjack/formatter/date_time_formatter.rb
+++ b/lib/lumberjack/formatter/date_time_formatter.rb
@@ -9,6 +9,8 @@ module Lumberjack
     # The formatter supports custom strftime patterns for complete control over output format,
     # while defaulting to ISO-8601 for standards compliance and readability.
     class DateTimeFormatter
+      FormatterRegistry.add(:date_time, self)
+
       # @!attribute [r] format
       #   @return [String, nil] The strftime format string, or nil for ISO-8601 default.
       attr_reader :format

--- a/lib/lumberjack/formatter/exception_formatter.rb
+++ b/lib/lumberjack/formatter/exception_formatter.rb
@@ -7,6 +7,8 @@ module Lumberjack
     # passed to this object and the returned array is what will be logged. You can
     # use this to clean out superfluous lines.
     class ExceptionFormatter
+      FormatterRegistry.add(:exception, self)
+
       # @!attribute [rw] backtrace_cleaner
       #   @return [#call, nil] An object that responds to `call` and takes
       #     an array of strings (the backtrace) and returns an array of strings.

--- a/lib/lumberjack/formatter/id_formatter.rb
+++ b/lib/lumberjack/formatter/id_formatter.rb
@@ -11,6 +11,8 @@ module Lumberjack
     # This is particularly useful for ActiveRecord models, database objects, or any objects that
     # have a unique identifier attribute.
     class IdFormatter
+      FormatterRegistry.add(:id, self)
+
       # @param id_attribute [Symbol, String] The attribute to use as the id (defaults to :id).
       def initialize(id_attribute = :id)
         @id_attribute = id_attribute

--- a/lib/lumberjack/formatter/inspect_formatter.rb
+++ b/lib/lumberjack/formatter/inspect_formatter.rb
@@ -11,6 +11,8 @@ module Lumberjack
     # or custom objects. It relies on Ruby's built-in `inspect` method,
     # which provides detailed object representations.
     class InspectFormatter
+      FormatterRegistry.add(:inspect, self)
+
       # Convert an object to its inspect representation.
       #
       # @param obj [Object] The object to format.

--- a/lib/lumberjack/formatter/multiply_formatter.rb
+++ b/lib/lumberjack/formatter/multiply_formatter.rb
@@ -8,6 +8,8 @@ module Lumberjack
     # This is useful for unit conversions (e.g., converting seconds to milliseconds)
     # or scaling values for display purposes. Non-numeric values are passed through unchanged.
     class MultiplyFormatter
+      FormatterRegistry.add(:multiply, self)
+
       # @param multiplier [Numeric] The multiplier to apply to the value.
       # @param decimals [Integer, nil] The number of decimal places to round the result to.
       #   If nil, no rounding is applied.

--- a/lib/lumberjack/formatter/object_formatter.rb
+++ b/lib/lumberjack/formatter/object_formatter.rb
@@ -10,6 +10,8 @@ module Lumberjack
     # the original data structure and let downstream components handle the actual
     # formatting, or when you need a placeholder formatter in the formatter chain.
     class ObjectFormatter
+      FormatterRegistry.add(:object, self)
+
       # Return the object unchanged.
       #
       # @param obj [Object] The object to format.

--- a/lib/lumberjack/formatter/pretty_print_formatter.rb
+++ b/lib/lumberjack/formatter/pretty_print_formatter.rb
@@ -12,6 +12,8 @@ module Lumberjack
     # The formatter uses Ruby's built-in PP (Pretty Print) library to generate
     # well-formatted output with appropriate indentation and line breaks.
     class PrettyPrintFormatter
+      FormatterRegistry.add(:pretty_print, self)
+
       # @!attribute [rw] width
       #   @return [Integer] The maximum width of the message.
       attr_accessor :width

--- a/lib/lumberjack/formatter/redact_formatter.rb
+++ b/lib/lumberjack/formatter/redact_formatter.rb
@@ -10,6 +10,8 @@ module Lumberjack
     # This formatter is useful for logging sensitive data while still providing
     # enough context to distinguish between different values during debugging.
     class RedactFormatter
+      FormatterRegistry.add(:redact, self)
+
       # Redact a string value by showing only the first and last characters.
       #
       # @param obj [Object] The object to format. Only strings are redacted.

--- a/lib/lumberjack/formatter/round_formatter.rb
+++ b/lib/lumberjack/formatter/round_formatter.rb
@@ -9,6 +9,8 @@ module Lumberjack
     # This makes it safe to use as a general-purpose formatter for attributes that
     # might contain various data types.
     class RoundFormatter
+      FormatterRegistry.add(:round, self)
+
       # @param precision [Integer] The number of decimal places to round to (defaults to 3).
       def initialize(precision = 3)
         @precision = precision

--- a/lib/lumberjack/formatter/string_formatter.rb
+++ b/lib/lumberjack/formatter/string_formatter.rb
@@ -6,6 +6,8 @@ module Lumberjack
     # implementation and is commonly used as a fallback for objects that don't
     # have specialized formatters.
     class StringFormatter
+      FormatterRegistry.add(:string, self)
+
       # Convert an object to its string representation.
       #
       # @param obj [Object] The object to format.

--- a/lib/lumberjack/formatter/strip_formatter.rb
+++ b/lib/lumberjack/formatter/strip_formatter.rb
@@ -10,6 +10,8 @@ module Lumberjack
     # making it ideal for attribute values that should be clean and consistent
     # in log output.
     class StripFormatter
+      FormatterRegistry.add(:strip, self)
+
       # Convert an object to a string and remove leading and trailing whitespace.
       #
       # @param obj [Object] The object to format.

--- a/lib/lumberjack/formatter/structured_formatter.rb
+++ b/lib/lumberjack/formatter/structured_formatter.rb
@@ -12,6 +12,8 @@ module Lumberjack
     # like configuration hashes, API responses, or any hierarchical data structures
     # that need consistent formatting throughout their entire structure.
     class StructuredFormatter
+      FormatterRegistry.add(:structured, self)
+
       # Exception raised when a circular reference is detected during traversal.
       # This prevents infinite recursion when formatting objects that reference themselves.
       class RecusiveReferenceError < StandardError

--- a/lib/lumberjack/formatter/tags_formatter.rb
+++ b/lib/lumberjack/formatter/tags_formatter.rb
@@ -8,6 +8,8 @@ module Lumberjack
   # - Hashes will be formatted as "[key1=value1] [key2=value2]"
   # - Hashes in arrays will be formatted as "[key=value]"
   class Formatter::TagsFormatter
+    FormatterRegistry.add(:tags, self)
+
     def call(tags)
       tags = tags.collect { |key, value| "#{key}=#{value}" } if tags.is_a?(Hash)
       if tags.is_a?(Array)

--- a/lib/lumberjack/formatter/truncate_formatter.rb
+++ b/lib/lumberjack/formatter/truncate_formatter.rb
@@ -10,6 +10,8 @@ module Lumberjack
     # When a string is truncated, it will have a unicode ellipsis
     # character (U+2026) appended to the end of the string.
     class TruncateFormatter
+      FormatterRegistry.add(:truncate, self)
+
       # @param length [Integer] The maximum length of the string (defaults to 32K).
       def initialize(length = 32768)
         @length = length

--- a/lib/lumberjack/formatter_registry.rb
+++ b/lib/lumberjack/formatter_registry.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Lumberjack
+  # The formatter registry is used for setting up names to represent Formatter classes. It is used
+  # in the constructor for Lumberjack::Logger and allows passing in a symbol to reference a
+  # formatter.
+  #
+  # Formatters must respond to the `call` method.
+  #
+  # @example
+  #
+  #   Lumberjack::FormatterRegistry.add(:upcase) { |value| value.to_s.upcase }
+  #   Lumberjack::FormatterRegistry.add(:currency, Lumberjack::Formatter::RoundFormatter, 2)
+  #
+  #   Lumberjack::EntryFormatter.build do
+  #     attributes do
+  #       add_attribute :status, :upcase
+  #       add_attribute :amount, :currency
+  #     end
+  #   end
+  module FormatterRegistry
+    @registry = {}
+
+    class << self
+      # Register a formatter name. Formatter names can be used to associate a symbol with a formatter
+      # class. The symbol can then be passed to Logger as the formatter argument.
+      #
+      # Registered formatters must take only one argument and that is the options hash for the
+      # formatter options.
+      #
+      # @param name [Symbol] The name of the formatter
+      # @param formatter [Class, #call] The formatter or formatter class to register..
+      # @return [void]
+      def add(name, formatter = nil, &block)
+        raise ArgumentError.new("name must be a symbol") unless name.is_a?(Symbol)
+        raise ArgumentError.new("formatter or block must be provided") if formatter.nil? && block.nil?
+        raise ArgumentError.new("cannot have both formatter and a block") if !formatter.nil? && !block.nil?
+
+        formatter ||= block
+        raise ArgumentError.new("formatter must be a class or respond to call") unless formatter.is_a?(Class) || formatter.respond_to?(:call)
+
+        @registry[name] = formatter
+      end
+
+      # Remove a formatter from the registry.
+      #
+      # @param name [Symbol] The name of the formatter to remove
+      # @return [void]
+      def remove(name)
+        @registry.delete(name)
+      end
+
+      # Check if a formatter is registered.
+      #
+      # @param name [Symbol] The name of the formatter
+      # @return [Boolean] True if the formatter is registered, false otherwise
+      def registered?(name)
+        @registry.include?(name)
+      end
+
+      # Retrieve the formatter registered with the given name or nil if the name is not defined.
+      #
+      # @param name [Symbol] The name of the formatter
+      # @return [#call, nil] The registered formatter class or nil if not found
+      def formatter(name, *args)
+        instance = @registry[name]
+
+        if instance.nil?
+          valid_names = @registry.keys.map(&:inspect).join(", ")
+          raise ArgumentError.new("#{name.inspect} is not registered as a formatter name; valid names are: #{valid_names}")
+        end
+
+        instance = instance.new(*args) if instance.is_a?(Class)
+
+        instance
+      end
+
+      # Return the map of registered formatters.
+      #
+      # @return [Hash]
+      def registered_formatters
+        @registry.dup
+      end
+    end
+  end
+end

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -432,7 +432,7 @@ module Lumberjack
 
       unless entry_formatter
         message_formatter ||= formatter if formatter.is_a?(Lumberjack::Formatter)
-        entry_formatter = Lumberjack::EntryFormatter.new
+        entry_formatter = Lumberjack::EntryFormatter.new(message_formatter: :default)
       end
 
       entry_formatter.message_formatter = message_formatter if message_formatter

--- a/spec/lumberjack/device/null_spec.rb
+++ b/spec/lumberjack/device/null_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Device::Null do
+  it "is registered as :null" do
+    expect(Lumberjack::DeviceRegistry.device_class(:null)).to eq(Lumberjack::Device::Null)
+  end
+
   it "should not generate any output" do
     device = Lumberjack::Device::Null.new
     device.write(Lumberjack::LogEntry.new(Time.now, 1, "New log entry", nil, Process.pid, nil))

--- a/spec/lumberjack/device/test_spec.rb
+++ b/spec/lumberjack/device/test_spec.rb
@@ -5,6 +5,10 @@ require "spec_helper"
 RSpec.describe Lumberjack::Device::Test do
   let(:device) { Lumberjack::Device::Test.new }
 
+  it "is registered as :test" do
+    expect(Lumberjack::DeviceRegistry.device_class(:test)).to eq(Lumberjack::Device::Test)
+  end
+
   describe "#max_entries" do
     it "is 1000 by default" do
       expect(device.max_entries).to eq(1000)

--- a/spec/lumberjack/entry_formatter_spec.rb
+++ b/spec/lumberjack/entry_formatter_spec.rb
@@ -4,8 +4,16 @@ require "spec_helper"
 
 RSpec.describe Lumberjack::EntryFormatter do
   describe "building formatters" do
-    it "starts with a default message formatter and no attribute formatter" do
+    it "starts with an empty message formatter and no attribute formatter" do
       entry_formatter = Lumberjack::EntryFormatter.new
+      expect(entry_formatter.message_formatter).to_not be_nil
+      expect(entry_formatter.attribute_formatter).to be_nil
+      obj = Object.new
+      expect(entry_formatter.message_formatter.format(obj)).to equal(obj)
+    end
+
+    it "uses the default formatter if message_formatter is :default" do
+      entry_formatter = Lumberjack::EntryFormatter.new(message_formatter: :default)
       expect(entry_formatter.message_formatter).to_not be_nil
       expect(entry_formatter.attribute_formatter).to be_nil
       obj = Object.new
@@ -52,6 +60,31 @@ RSpec.describe Lumberjack::EntryFormatter do
 
       expect(entry_formatter.message_formatter.format("foobar")).to eq("FOOBAR")
       expect(entry_formatter.attribute_formatter.format("status" => "new")).to eq({"status" => "[new]"})
+    end
+  end
+
+  describe "#merge" do
+    it "merges the formats from the formatter" do
+      formatter_1 = Lumberjack::EntryFormatter.build do
+        add(String) { |obj| obj.to_s.upcase }
+        attributes do
+          add("status") { |obj| "[#{obj}]" }
+        end
+      end
+
+      formatter_2 = Lumberjack::EntryFormatter.build do
+        add(String) { |obj| obj.to_s.downcase }
+        attributes do
+          add("foo") { |obj| "(#{obj})" }
+        end
+      end
+
+      expect(formatter_2.merge(formatter_1)).to eq formatter_2
+
+      message, attributes = formatter_2.format("foobar", {"status" => "new", "foo" => "bar"})
+
+      expect(message).to eq("FOOBAR")
+      expect(attributes).to eq({"status" => "[new]", "foo" => "(bar)"})
     end
   end
 

--- a/spec/lumberjack/formatter/date_time_formatter_spec.rb
+++ b/spec/lumberjack/formatter/date_time_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::DateTimeFormatter do
+  it "is registered as :date_time" do
+    expect(Lumberjack::FormatterRegistry.formatter(:date_time, "YYYY-mm-dd")).to be_a(Lumberjack::Formatter::DateTimeFormatter)
+  end
+
   it "should format a time object" do
     time = Time.now
     formatter = Lumberjack::Formatter::DateTimeFormatter.new("%Y-%m-%d %H:%M")

--- a/spec/lumberjack/formatter/exception_formatter_spec.rb
+++ b/spec/lumberjack/formatter/exception_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::ExceptionFormatter do
+  it "is registered as :exception" do
+    expect(Lumberjack::FormatterRegistry.formatter(:exception)).to be_a(Lumberjack::Formatter::ExceptionFormatter)
+  end
+
   it "should convert an exception without a backtrace to a string" do
     e = ArgumentError.new("not expected")
     formatter = Lumberjack::Formatter::ExceptionFormatter.new

--- a/spec/lumberjack/formatter/id_formatter_spec.rb
+++ b/spec/lumberjack/formatter/id_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::IdFormatter do
+  it "is registered as :id" do
+    expect(Lumberjack::FormatterRegistry.formatter(:id)).to be_a(Lumberjack::Formatter::IdFormatter)
+  end
+
   it "should format an object as a hash of class and id" do
     obj = Object.new
     def obj.id

--- a/spec/lumberjack/formatter/inspect_formatter_spec.rb
+++ b/spec/lumberjack/formatter/inspect_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::InspectFormatter do
+  it "is registered as :inspect" do
+    expect(Lumberjack::FormatterRegistry.formatter(:inspect)).to be_a(Lumberjack::Formatter::InspectFormatter)
+  end
+
   it "should format objects as string by calling their inspect method" do
     formatter = Lumberjack::Formatter::InspectFormatter.new
     expect(formatter.call("abc")).to eq("\"abc\"")

--- a/spec/lumberjack/formatter/multiply_formatter_spec.rb
+++ b/spec/lumberjack/formatter/multiply_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::MultiplyFormatter do
+  it "is registered as :multiply" do
+    expect(Lumberjack::FormatterRegistry.formatter(:multiply, 2)).to be_a(Lumberjack::Formatter::MultiplyFormatter)
+  end
+
   it "multiplies a numeric value" do
     formatter = Lumberjack::Formatter::MultiplyFormatter.new(2)
     expect(formatter.call(5)).to eq(10)

--- a/spec/lumberjack/formatter/object_formatter_spec.rb
+++ b/spec/lumberjack/formatter/object_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::ObjectFormatter do
+  it "is registered as :object" do
+    expect(Lumberjack::FormatterRegistry.formatter(:object)).to be_a(Lumberjack::Formatter::ObjectFormatter)
+  end
+
   it "should return the object itself" do
     formatter = Lumberjack::Formatter::ObjectFormatter.new
     obj = Object.new

--- a/spec/lumberjack/formatter/pretty_print_formatter_spec.rb
+++ b/spec/lumberjack/formatter/pretty_print_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::PrettyPrintFormatter do
+  it "is registered as :pretty_print" do
+    expect(Lumberjack::FormatterRegistry.formatter(:pretty_print)).to be_a(Lumberjack::Formatter::PrettyPrintFormatter)
+  end
+
   it "should convert an object to a string using pretty print" do
     object = Object.new
     def object.pretty_print(q)

--- a/spec/lumberjack/formatter/redact_formatter_spec.rb
+++ b/spec/lumberjack/formatter/redact_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::RedactFormatter do
+  it "is registered as :redact" do
+    expect(Lumberjack::FormatterRegistry.formatter(:redact)).to be_a(Lumberjack::Formatter::RedactFormatter)
+  end
+
   it "should redact long strings" do
     formatter = Lumberjack::Formatter::RedactFormatter.new
     expect(formatter.call("1234567890")).to eq("12******90")

--- a/spec/lumberjack/formatter/round_formtter_spec.rb
+++ b/spec/lumberjack/formatter/round_formtter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::RoundFormatter do
+  it "is registered as :round" do
+    expect(Lumberjack::FormatterRegistry.formatter(:round, 1)).to be_a(Lumberjack::Formatter::RoundFormatter)
+  end
+
   it "should round a numeric value" do
     formatter = Lumberjack::Formatter::RoundFormatter.new
     expect(formatter.call(1.23456789)).to eq(1.235)

--- a/spec/lumberjack/formatter/string_formatter_spec.rb
+++ b/spec/lumberjack/formatter/string_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::StringFormatter do
+  it "is registered as :string" do
+    expect(Lumberjack::FormatterRegistry.formatter(:string)).to be_a(Lumberjack::Formatter::StringFormatter)
+  end
+
   it "should format objects as string by calling their to_s method" do
     formatter = Lumberjack::Formatter::StringFormatter.new
     expect(formatter.call("abc")).to eq("abc")

--- a/spec/lumberjack/formatter/strip_formatter_spec.rb
+++ b/spec/lumberjack/formatter/strip_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::StripFormatter do
+  it "is registered as :strip" do
+    expect(Lumberjack::FormatterRegistry.formatter(:strip)).to be_a(Lumberjack::Formatter::StripFormatter)
+  end
+
   it "should format objects as strings with leading and trailing whitespace removed" do
     formatter = Lumberjack::Formatter::StripFormatter.new
     expect(formatter.call(" abc \n")).to eq("abc")

--- a/spec/lumberjack/formatter/structured_formatter_spec.rb
+++ b/spec/lumberjack/formatter/structured_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::StructuredFormatter do
+  it "is registered as :structured" do
+    expect(Lumberjack::FormatterRegistry.formatter(:structured)).to be_a(Lumberjack::Formatter::StructuredFormatter)
+  end
+
   it "should recursively format arrays and hashes" do
     formatter = Lumberjack::Formatter.new.clear
     formatter.add(Enumerable, Lumberjack::Formatter::StructuredFormatter.new(formatter))

--- a/spec/lumberjack/formatter/tags_formatter_spec.rb
+++ b/spec/lumberjack/formatter/tags_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::TagsFormatter do
+  it "is registered as :tags" do
+    expect(Lumberjack::FormatterRegistry.formatter(:tags)).to be_a(Lumberjack::Formatter::TagsFormatter)
+  end
+
   describe "#call" do
     it "formats a hash of tags" do
       formatter = Lumberjack::Formatter::TagsFormatter.new

--- a/spec/lumberjack/formatter/truncate_formatter_spec.rb
+++ b/spec/lumberjack/formatter/truncate_formatter_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter::TruncateFormatter do
+  it "is registered as :truncate" do
+    expect(Lumberjack::FormatterRegistry.formatter(:truncate)).to be_a(Lumberjack::Formatter::TruncateFormatter)
+  end
+
   it "should truncate a string longer than the limit" do
     formatter = Lumberjack::Formatter::TruncateFormatter.new(9)
     expect(formatter.call("1234567890")).to eq "12345678…"

--- a/spec/lumberjack/formatter_registry_spec.rb
+++ b/spec/lumberjack/formatter_registry_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lumberjack::FormatterRegistry do
+  after do
+    Lumberjack::FormatterRegistry.remove(:test)
+  end
+
+  it "can add a formatter as a block" do
+    expect(Lumberjack::FormatterRegistry.registered?(:test)).to be false
+    Lumberjack::FormatterRegistry.add(:test) { |value| value.to_s.upcase }
+    expect(Lumberjack::FormatterRegistry.registered?(:test)).to be true
+    formatter = Lumberjack::FormatterRegistry.formatter(:test)
+    expect(formatter.call("Test")).to eq("TEST")
+  end
+
+  it "can add a formatter with an object" do
+    formatter = lambda { |value| value.to_s.capitalize }
+    Lumberjack::FormatterRegistry.add(:test, formatter)
+    expect(Lumberjack::FormatterRegistry.formatter(:test)).to eq(formatter)
+  end
+
+  it "can add a formatter as a class" do
+    Lumberjack::FormatterRegistry.add(:test, Lumberjack::Formatter::TruncateFormatter)
+    formatter = Lumberjack::FormatterRegistry.formatter(:test, 3)
+    expect(formatter.call("Test")).to eq("Te…")
+  end
+
+  it "raises an error if the formatter is not registered" do
+    expect { Lumberjack::FormatterRegistry.formatter(:unknown) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/lumberjack/formatter_spec.rb
+++ b/spec/lumberjack/formatter_spec.rb
@@ -3,10 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Lumberjack::Formatter do
-  let(:formatter) { Lumberjack::Formatter.new }
+  let(:formatter) { Lumberjack::Formatter.default }
 
   describe "optimized formatters for primitive types" do
-    let(:formatter) { Lumberjack::Formatter.empty.add(Object, :inspect) }
+    let(:formatter) { Lumberjack::Formatter.new.add(Object, :inspect) }
 
     it "should have an optimized set of formatters that return self for primitive types" do
       expect(formatter.format("foo")).to eq("foo")
@@ -35,109 +35,137 @@ RSpec.describe Lumberjack::Formatter do
     end
   end
 
-  it "should have a default set of formatters" do
-    expect(formatter.format("abc")).to eq("abc")
-    expect(formatter.format([1, 2, 3])).to eq([1, 2, 3])
-    expect(formatter.format(ArgumentError.new("boom"))).to eq("ArgumentError: boom")
-  end
+  describe "#format" do
+    it "should have a default set of formatters" do
+      expect(formatter.format("abc")).to eq("abc")
+      expect(formatter.format([1, 2, 3])).to eq([1, 2, 3])
+      expect(formatter.format(ArgumentError.new("boom"))).to eq("ArgumentError: boom")
+    end
 
-  it "should be able to add a formatter object for a class" do
-    formatter.add(Numeric, lambda { |obj| "number: #{obj}" })
-    expect(formatter.format(10)).to eq("number: 10")
-  end
+    it "should be able to add a formatter object for a class" do
+      formatter.add(Numeric, lambda { |obj| "number: #{obj}" })
+      expect(formatter.format(10)).to eq("number: 10")
+    end
 
-  it "should be able to add a formatter object for a class name" do
-    formatter.add("Numeric", lambda { |obj| "number: #{obj}" })
-    expect(formatter.format(10)).to eq("number: 10")
-  end
+    it "should be able to add a formatter object for a class name" do
+      formatter.add("Numeric", lambda { |obj| "number: #{obj}" })
+      expect(formatter.format(10)).to eq("number: 10")
+    end
 
-  it "should be able to add a formatter object for multiple classes" do
-    formatter.add([Numeric, NilClass], &:to_i)
-    expect(formatter.format(10.1)).to eq(10)
-    expect(formatter.format(nil)).to eq(0)
-  end
+    it "should be able to add a formatter object for multiple classes" do
+      formatter.add([Numeric, NilClass], &:to_i)
+      expect(formatter.format(10.1)).to eq(10)
+      expect(formatter.format(nil)).to eq(0)
+    end
 
-  it "should be able to add a formatter with arguments" do
-    formatter.add(String, "Lumberjack::Formatter::TruncateFormatter", 9)
-    expect(formatter.format("1234567890")).to eq("12345678…")
-  end
+    it "should be able to add a formatter with arguments" do
+      formatter.add(String, :truncate, 9)
+      expect(formatter.format("1234567890")).to eq("12345678…")
+    end
 
-  it "should be able to add a formatter object for a module" do
-    formatter.add(Enumerable, lambda { |obj| "list: #{obj.inspect}" })
-    expect(formatter.format([1, 2])).to eq("list: [1, 2]")
-  end
+    it "should be able to add a formatter object for a module" do
+      formatter.add(Enumerable, lambda { |obj| "list: #{obj.inspect}" })
+      expect(formatter.format([1, 2])).to eq("list: [1, 2]")
+    end
 
-  it "should be able to add a formatter block for a class" do
-    formatter.add(Numeric) { |obj| "number: #{obj}" }
-    expect(formatter.format(10)).to eq("number: 10")
-  end
+    it "should be able to add a formatter block for a class" do
+      formatter.add(Numeric) { |obj| "number: #{obj}" }
+      expect(formatter.format(10)).to eq("number: 10")
+    end
 
-  it "should be able to remove a formatter for a class" do
-    formatter = Lumberjack::Formatter.empty
-    formatter.add(Symbol, :inspect)
-    expect(formatter.format(:foo)).to eq(":foo")
-    formatter.remove(Symbol)
-    expect(formatter.format(:foo)).to eq(:foo)
-  end
+    it "should be able to remove a formatter for a class" do
+      formatter = Lumberjack::Formatter.new
+      formatter.add(Symbol, :inspect)
+      expect(formatter.format(:foo)).to eq(":foo")
+      formatter.remove(Symbol)
+      expect(formatter.format(:foo)).to eq(:foo)
+    end
 
-  it "should be able to remove a formatter for a class" do
-    formatter = Lumberjack::Formatter.empty
-    formatter.add([Symbol, Array], :inspect)
-    expect(formatter.format(:foo)).to eq(":foo")
-    formatter.remove([Symbol, Array])
-    expect(formatter.format(:foo)).to eq(:foo)
-  end
+    it "should be able to remove a formatter for a class" do
+      formatter = Lumberjack::Formatter.new
+      formatter.add([Symbol, Array], :inspect)
+      expect(formatter.format(:foo)).to eq(":foo")
+      formatter.remove([Symbol, Array])
+      expect(formatter.format(:foo)).to eq(:foo)
+    end
 
-  it "should be able to remove multiple formatters" do
-    formatter = Lumberjack::Formatter.empty
-    formatter.add([Symbol, Array], :inspect)
-    expect(formatter.format(:foo)).to eq(":foo")
-    expect(formatter.format([1, 2, 3])).to eq([1, 2, 3].inspect)
-    formatter.remove([Symbol, Array])
-    expect(formatter.format(:foo)).to eq(:foo)
-    expect(formatter.format([1, 2, 3])).to eq([1, 2, 3])
-  end
+    it "should be able to remove multiple formatters" do
+      formatter = Lumberjack::Formatter.new
+      formatter.add([Symbol, Array], :inspect)
+      expect(formatter.format(:foo)).to eq(":foo")
+      expect(formatter.format([1, 2, 3])).to eq([1, 2, 3].inspect)
+      formatter.remove([Symbol, Array])
+      expect(formatter.format(:foo)).to eq(:foo)
+      expect(formatter.format([1, 2, 3])).to eq([1, 2, 3])
+    end
 
-  it "should be able to chain add and remove calls" do
-    expect(formatter.remove(String)).to eq(formatter)
-    expect(formatter.add(String, Lumberjack::Formatter::StringFormatter.new)).to eq(formatter)
-  end
+    it "should be able to chain add and remove calls" do
+      expect(formatter.remove(String)).to eq(formatter)
+      expect(formatter.add(String, Lumberjack::Formatter::StringFormatter.new)).to eq(formatter)
+    end
 
-  it "should format an object based on the class hierarchy" do
-    formatter.add(Numeric) { |obj| "number: #{obj}" }
-    formatter.add(Integer) { |obj| "fixed number: #{obj}" }
-    expect(formatter.format(10)).to eq("fixed number: 10")
-    expect(formatter.format(10.1)).to eq("number: 10.1")
-  end
+    it "should format an object based on the class hierarchy" do
+      formatter.add(Numeric) { |obj| "number: #{obj}" }
+      formatter.add(Integer) { |obj| "fixed number: #{obj}" }
+      expect(formatter.format(10)).to eq("fixed number: 10")
+      expect(formatter.format(10.1)).to eq("number: 10.1")
+    end
 
-  it "should have a default formatter" do
-    expect(formatter.format(:test)).to eq(":test")
-    formatter.remove(Object)
-    expect(formatter.format(:test)).to eq(:test)
-  end
-
-  it "applies the to_log_format method if there is no registered formatter" do
-    obj = TestToLogFormat.new("test")
-    expect(formatter.format(obj)).to eq("LOG FORMAT: test")
-  end
-
-  it "overrides the to_log_format method if there is a registered formatter" do
-    formatter.add(TestToLogFormat) { |obj| obj.value.upcase }
-    obj = TestToLogFormat.new("test")
-    expect(formatter.format(obj)).to eq("TEST")
-  end
-
-  describe "clear" do
-    it "should clear all mappings" do
+    it "should have a default formatter" do
       expect(formatter.format(:test)).to eq(":test")
-      formatter.clear
+      formatter.remove(Object)
       expect(formatter.format(:test)).to eq(:test)
+    end
+
+    it "applies the to_log_format method if there is no registered formatter" do
+      obj = TestToLogFormat.new("test")
+      expect(formatter.format(obj)).to eq("LOG FORMAT: test")
+    end
+
+    it "overrides the to_log_format method if there is a registered formatter" do
+      formatter.add(TestToLogFormat) { |obj| obj.value.upcase }
+      obj = TestToLogFormat.new("test")
+      expect(formatter.format(obj)).to eq("TEST")
+    end
+
+    it "does not override the to_log_format if the registered formatter is on a parent class" do
+      formatter.add(:object) { |obj| "Object:#{obj.object_id}" }
+      obj = TestToLogFormat.new("test")
+      expect(formatter.format(obj)).to eq("LOG FORMAT: test")
+    end
+
+    describe "clear" do
+      it "should clear all mappings" do
+        expect(formatter.format(:test)).to eq(":test")
+        formatter.clear
+        expect(formatter.format(:test)).to eq(:test)
+      end
     end
   end
 
   describe "empty" do
     it "should be able to get an empty formatter" do
-      expect(Lumberjack::Formatter.empty.format(:test)).to eq(:test)
+      silence_deprecations do
+        expect(Lumberjack::Formatter.empty.format(:test)).to eq(:test)
+      end
+    end
+  end
+
+  describe "#merge" do
+    it "merges the formats from the formatter" do
+      formatter_1 = Lumberjack::Formatter.new
+      formatter_1.add(String) { |s| s.to_s.upcase }
+      formatter_1.add(Float, :round, 1)
+
+      formatter_2 = Lumberjack::Formatter.new
+      formatter_2.add(String) { |s| s.to_s.downcase }
+      formatter_2.add(Integer, :multiply, 2)
+
+      expect(formatter_2.merge(formatter_1)).to eq formatter_2
+
+      expect(formatter_2.format("test")).to eq("TEST")
+      expect(formatter_2.format(3.14)).to eq(3.1)
+      expect(formatter_2.format(2)).to eq(4)
     end
   end
 end

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe Lumberjack::Logger do
       expect(logger.formatter).to be
     end
 
+    it "uses the default message formatter by default" do
+      logger = Lumberjack::Logger.new(:test)
+      obj = Object.new
+      expect(logger.message_formatter.format(obj)).to eq(obj.inspect)
+    end
+
     it "should have a message formatter" do
       out = StringIO.new
       logger = Lumberjack::Logger.new(out)


### PR DESCRIPTION
- Add `merge` method on formatter classes to merge formats from other formatters. This enables creating reusable formatters that can be composed into a logger's formatter.
- Add registry for formatters so that specifying a formatter by symbol is no longer limited to the built in formatters.