### PR TITLE
Add remap attribute feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Added `Lumberjack::FormatterRegistry` as a means of associating formatters with a symbol. Symbols can be used when adding class and attribute formatters. This extends the behavior previously limited to the built in formatters so that users can define their own formatters and register them for use.
 - Added `Lumberjack::DeviceRegistry` as a means for associating devices with a symbol. Symbols can then be passed to the constructor when creating a logger and the logger will take care of instantiating the device.
 - Added `Lumberjack::Logger#clear_attributes` to remove all attributes from the logger.
+- Added `Lumberjack::MessageAttributes` to replace `Lumberjack::Formatter::TaggedMessage`.
+- Added `Lumberjack::RemapAttribute` to facilitate attribute remapping in attribute formatters.
 
 ### Changed
 
@@ -80,6 +82,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
   - `Lumberjack::Logger::TagContext`
   - `Lumberjack::Logger::TagFormatter`
   - `Lumberjack::Logger::Tags`
+  - `Lumberjack::Formatter::TaggedMessage`
 - The Rails compatibility methods on `Lumberjack::Logger` (`tagged`, `silence`, `log_at`) have been moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem. Installing that gem will restore these methods in a non-deprecated form.
 
 ## 1.4.0

--- a/README.md
+++ b/README.md
@@ -287,11 +287,11 @@ end
 logger.formatter.add(SecureString, PasswordFormatter.new)
 ```
 
-For log messages you can use the `Lumberjack::Formatter::TaggedMessage` to extract structured data from a log message. This can be used to allow logging objects directly and extracting metadata from the objects in the log attributes.
+For log messages you can use the `Lumberjack::MessageAttributes` class to extract structured data from a log message. This can be used to allow logging objects directly and extracting metadata from the objects in the log attributes.
 
 ```ruby
 logger.formatter.add(Exception) do |error|
-  Lumberjack::Formatter::TaggedMessage.new(
+  Lumberjack::MessageAttributes.new(
     error.inspect,
     error: {
       type: error.class.name,
@@ -352,6 +352,13 @@ logger.info("Data processed",
   created_at: Time.now,          # → "2025-08-22 14:30:00"
   price: 29.099,                 # → 29.10
 )
+```
+
+You can remap attributes to other attribute names by returning a `Lumberjack::RemapAttribute` instance.
+
+```ruby
+# Move the email attribute under the user attributes.
+logger.attribute_formatter.add("email") { |value| Lumberjack::RemapAttribute.new("user.email" => value) }
 ```
 
 Finally, you can add a default formatter for all other attributes:

--- a/README.old.md
+++ b/README.old.md
@@ -237,11 +237,11 @@ logger.message_formatter.add(String, :truncate, 1000)  # Will truncate all strin
 
 ##### Extracting Tags from Messages
 
-If you are using structured logging, you can use a formatter to extract tags from the log message by adding a formatter that returns a `Lumberjack::Formatter::TaggedMessage`. For example, if you want to extract metadata from exceptions and add them as tags, you could do this:
+If you are using structured logging, you can use a formatter to extract tags from the log message by adding a formatter that returns a `Lumberjack::MessageAttributes`. For example, if you want to extract metadata from exceptions and add them as tags, you could do this:
 
 ```ruby
 logger.message_formatter.add(Exception, ->(e) {
-  Lumberjack::Formatter::TaggedMessage.new(e.inspect, {
+  Lumberjack::MessageAttributes.new(e.inspect, {
     "error.message": e.message,
     "error.class": e.class.name,
     "error.trace": e.backtrace

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -49,6 +49,8 @@ module Lumberjack
   require_relative "lumberjack/formatter"
   require_relative "lumberjack/forked_logger"
   require_relative "lumberjack/logger"
+  require_relative "lumberjack/message_attributes"
+  require_relative "lumberjack/remap_attribute"
   require_relative "lumberjack/rack"
   require_relative "lumberjack/severity"
   require_relative "lumberjack/template"

--- a/lib/lumberjack/entry_formatter.rb
+++ b/lib/lumberjack/entry_formatter.rb
@@ -16,7 +16,7 @@ module Lumberjack
   # - Delegates attribute formatting to an AttributeFormatter instance
   # - Provides a unified configuration interface through method chaining
   # - Handles the coordination between message and attribute formatting
-  # - Manages special message types like TaggedMessage that carry embedded attributes
+  # - Manages special message types like MessageAttributes that carry embedded attributes
   #
   # @example Complete entry formatting setup
   #   formatter = Lumberjack::EntryFormatter.build do
@@ -184,7 +184,7 @@ module Lumberjack
       message = message_formatter.format(message) if message_formatter.respond_to?(:format)
 
       message_attributes = nil
-      if message.is_a?(Formatter::TaggedMessage)
+      if message.is_a?(MessageAttributes)
         message_attributes = message.attributes
         message = message.message
       end
@@ -214,7 +214,7 @@ module Lumberjack
     private
 
     # Merge two attribute hashes, handling nil values gracefully.
-    # Used to combine explicit log attributes with attributes embedded in TaggedMessage objects.
+    # Used to combine explicit log attributes with attributes embedded in MessageAttributes objects.
     #
     # @param current_attributes [Hash, nil] The primary attributes hash.
     # @param attributes [Hash, nil] Additional attributes to merge in.

--- a/lib/lumberjack/formatter.rb
+++ b/lib/lumberjack/formatter.rb
@@ -294,7 +294,7 @@ module Lumberjack
     # @return [String] The formatted message with line separator.
     def call(severity, timestamp, progname, msg)
       formatted_message = format(msg)
-      formatted_message = formatted_message.message if formatted_message.is_a?(TaggedMessage)
+      formatted_message = formatted_message.message if formatted_message.is_a?(MessageAttributes)
       "#{formatted_message}#{Lumberjack::LINE_SEPARATOR}"
     end
 

--- a/lib/lumberjack/formatter/tagged_message.rb
+++ b/lib/lumberjack/formatter/tagged_message.rb
@@ -1,38 +1,15 @@
 # frozen_string_literal: true
 
+require_relative "../message_attributes"
+
 module Lumberjack
-  class Formatter
-    # This class can be used as the return value from a formatter `call` method to
-    # extract additional attributes from an object being logged. This can be useful when there
-    # using structured logging to include important metadata in the log message.
-    #
-    # @example
-    #  # Automatically add attributes with error details when logging an exception.
-    #  logger.add_formatter(Exception, ->(e) {
-    #    Lumberjack::Formatter::TaggedMessage.new(e.inspect, {
-    #      error: {
-    #        message: e.message,
-    #        class: e.class.name,
-    #        stack: e.backtrace
-    #      }
-    #    })
-    #  })
-    class TaggedMessage
-      attr_reader :message, :attributes
-
-      # @param formatter [Formatter] The formatter to apply the transformation to.
-      # @param transform [Proc] The transformation function to apply to the formatted string.
-      def initialize(message, attributes)
-        @message = message
-        @attributes = attributes || {}
-      end
-
-      def to_s
-        inspect
-      end
-
-      def inspect
-        {message: @message, attributes: @attributes}.inspect
+  # This is a deprecated alias for Lumberjack::MessageAttributes.
+  #
+  # @see MessageAttributes
+  class Formatter::TaggedMessage < MessageAttributes
+    def initialize(message, attributes)
+      Utils.deprecated("Lumberjack::Formatter::TaggedMessage", "Use Lumberjack::MessageAttributes instead.") do
+        super
       end
     end
   end

--- a/lib/lumberjack/message_attributes.rb
+++ b/lib/lumberjack/message_attributes.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Lumberjack
+  # This class can be used as the return value from a formatter `call` method to
+  # extract additional attributes from an object being logged. This can be useful when there
+  # using structured logging to include important metadata in the log entry in addition
+  # to the message.
+  #
+  # @example
+  #  # Automatically add attributes with error details when logging an exception.
+  #  logger.add_formatter(Exception, ->(e) {
+  #    Lumberjack::MessageAttributes.new(e.inspect, {
+  #      error: {
+  #        message: e.message,
+  #        class: e.class.name,
+  #        stack: e.backtrace
+  #      }
+  #    })
+  #  })
+  class MessageAttributes
+    attr_reader :message, :attributes
+
+    # @param formatter [Formatter] The formatter to apply the transformation to.
+    # @param transform [Proc] The transformation function to apply to the formatted string.
+    def initialize(message, attributes)
+      @message = message
+      @attributes = attributes || {}
+    end
+
+    def to_s
+      inspect
+    end
+
+    def inspect
+      {message: @message, attributes: @attributes}.inspect
+    end
+  end
+end

--- a/lib/lumberjack/remap_attribute.rb
+++ b/lib/lumberjack/remap_attribute.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Lumberjack
+  # This class can be used as a return value from an AttributeFormatter to indicate that the
+  # value should be remapped to a new attribute name.
+  class RemapAttribute
+    attr_reader :attributes
+
+    # @param remapped_attribute [Hash] The remapped attribute with the new names.
+    def initialize(remapped_attributes)
+      @attributes = Lumberjack::Utils.flatten_attributes(remapped_attributes)
+    end
+  end
+end

--- a/spec/lumberjack/entry_formatter_spec.rb
+++ b/spec/lumberjack/entry_formatter_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Lumberjack::EntryFormatter do
     end
 
     it "splits the message and attributes if the message formatter is a attributeged message" do
-      entry_formatter.add(String) { |obj| Lumberjack::Formatter::TaggedMessage.new("attributeged: #{obj}", {"attribute" => obj}) }
+      entry_formatter.add(String) { |obj| Lumberjack::MessageAttributes.new("attributeged: #{obj}", {"attribute" => obj}) }
       message, attributes = entry_formatter.format("foobar", {"foo" => "bar"})
       expect(message).to eq("attributeged: foobar")
       expect(attributes).to eq({"attribute" => "foobar", "foo" => "bar"})

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -466,9 +466,9 @@ RSpec.describe Lumberjack::Logger do
         expect(out.string.chomp).to eq "tset"
       end
 
-      it "should copy attributes from the message if the formatter returns a Lumberjack::Formatter::TaggedMessage" do
+      it "should copy attributes from the message if the formatter returns a Lumberjack::MessageAttributes" do
         logger = Lumberjack::Logger.new(out, template: ":message :attributes")
-        logger.formatter.add(String) { |msg| Lumberjack::Formatter::TaggedMessage.new(msg.upcase, tag: msg.downcase) }
+        logger.formatter.add(String) { |msg| Lumberjack::MessageAttributes.new(msg.upcase, tag: msg.downcase) }
         logger.info("Test")
         expect(out.string.chomp).to eq "TEST [tag:test]"
       end
@@ -514,9 +514,9 @@ RSpec.describe Lumberjack::Logger do
         expect(logger.attributes).to eq({"wip" => "wap"})
       end
 
-      it "should be able to extract attributes from an object with a formatter that returns Lumberjack::Formatter::TaggedMessage" do
+      it "should be able to extract attributes from an object with a formatter that returns Lumberjack::MessageAttributes" do
         logger.formatter.add(Exception, ->(e) {
-          Lumberjack::Formatter::TaggedMessage.new(e.inspect, {message: e.message, class: e.class.name})
+          Lumberjack::MessageAttributes.new(e.inspect, {message: e.message, class: e.class.name})
         })
         error = StandardError.new("foobar")
         logger.info(error)


### PR DESCRIPTION
- Added `Lumberjack::MessageAttributes` to replace `Lumberjack::Formatter::TaggedMessage`.
- Added `Lumberjack::RemapAttribute` to facilitate attribute remapping in attribute formatters.
