### PR TITLE
Rename formatter.merge to include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - `LumberJack::Logger#context` now yields a `Lumberjack::Context` rather than a `Lumberjack::TagContext`. It must be called with a block and can no longer be used to return the current context. `Lumberjack#context` must also now be called with a block. **Breaking Change**
 - `Lumberjack::TagContext` has been renamed to `Lumberjack::AttributesHelper`.
 - `Lumberjack::TagFormatter` has been renamed to `Lumberjack::AttributeFormatter`.
-- `Lumberjack::Formatter` no longer includes any default formats. You can still get the default formatter with `Lumberjack::Formatter.default`. This formatter will still be used when instantiating a logger without specifying a formatter. You can use the new `merge` method to merge in the default formats from this formatter. The `empty` method has been deprecated since it is no longer needed. **Breaking Change**
+- `Lumberjack::Formatter` no longer includes any default formats. You can still get the default formatter with `Lumberjack::Formatter.default`. This formatter will still be used when instantiating a logger without specifying a formatter. You can use the `include` method to merge in the default formats from this formatter. The `empty` method has been deprecated since it is no longer needed. **Breaking Change**
 - `Lumberjack::Logger#add_entry` does not check the logger level and will add the entry regardless of the severity. This method is an internal API method and is now documented as such.
 - Logging to files will now use the standard library `Logger::LogDevice` class for file output and rolling.
 - The `Lumberjack::Device::Writer` class now takes an `autoflush` option. Setting it to false will disable synchronous I/O.

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ logger = Lumberjack::Logger.new(STDOUT, formatter: entry_formatter)
 
 #### Merging Formatters
 
-You can merge other formatters into your formatter with the `merge` method. Doing so will copy all of the format definitions.
+You can merge other formatters into your formatter with the `include` method. Doing so will copy all of the format definitions.
 
 ```ruby
 # Translate the duration tag to microseconds.
@@ -441,7 +441,7 @@ end
 
 formatter = Lumberjack::EntryFormatter.build do
   # Adds the duration attribute formatter
-  merge(duration_formatter)
+  include(duration_formatter)
 end
 ```
 

--- a/lib/lumberjack/attribute_formatter.rb
+++ b/lib/lumberjack/attribute_formatter.rb
@@ -250,12 +250,12 @@ module Lumberjack
     #
     # @param formatter [Lumberjack::AttributeFormatter] The formatter to merge.
     # @return [self] Returns self for method chaining.
-    def merge(formatter)
+    def include(formatter)
       unless formatter.is_a?(Lumberjack::AttributeFormatter)
         raise ArgumentError.new("formatter must be a Lumberjack::AttributeFormatter")
       end
 
-      @class_formatter.merge(formatter.instance_variable_get(:@class_formatter))
+      @class_formatter.include(formatter.instance_variable_get(:@class_formatter))
       @attribute_formatter.merge!(formatter.instance_variable_get(:@attribute_formatter))
 
       default_formatter = formatter.instance_variable_get(:@default_formatter)

--- a/lib/lumberjack/entry_formatter.rb
+++ b/lib/lumberjack/entry_formatter.rb
@@ -158,16 +158,16 @@ module Lumberjack
     #
     # @param formatter [Lumberjack::EntryFormatter] The formatter to merge.
     # @return [self] Returns self for method chaining.
-    def merge(formatter)
+    def include(formatter)
       unless formatter.is_a?(Lumberjack::EntryFormatter)
         raise ArgumentError.new("formatter must be a Lumberjack::EntryFormatter")
       end
 
       @message_formatter ||= Lumberjack::Formatter.new
-      @message_formatter.merge(formatter.message_formatter)
+      @message_formatter.include(formatter.message_formatter)
 
       @attribute_formatter ||= Lumberjack::AttributeFormatter.new
-      @attribute_formatter.merge(formatter.attribute_formatter)
+      @attribute_formatter.include(formatter.attribute_formatter)
 
       self
     end

--- a/lib/lumberjack/formatter.rb
+++ b/lib/lumberjack/formatter.rb
@@ -220,12 +220,14 @@ module Lumberjack
     #
     # @param formatter [Lumberjack::Formatter] The formatter to merge.
     # @return [self] Returns self for method chaining.
-    def merge(formatter)
+    def include(formatter)
       unless formatter.is_a?(Lumberjack::Formatter)
         raise ArgumentError.new("formatter must be a Lumberjack::Formatter")
       end
 
-      @class_formatters.merge!(formatter.instance_variable_get(:@class_formatters))
+      formatter.instance_variable_get(:@class_formatters).each do |class_name, fmttr|
+        add(class_name, fmttr)
+      end
 
       self
     end

--- a/lib/lumberjack/utils.rb
+++ b/lib/lumberjack/utils.rb
@@ -41,11 +41,8 @@ module Lumberjack
           @deprecations_lock.synchronize do
             @deprecations ||= {}
             unless @deprecations.include?(method)
-              trace = caller[3..]
-              unless $VERBOSE
-                trace = [trace.first]
-                @deprecations[method] = true
-              end
+              trace = $VERBOSE ? caller[3..] : caller[3, 1]
+              @deprecations[method] = true
               message = "DEPRECATION WARNING: #{message} Called from #{trace.join("\n")}"
               warn(message)
             end

--- a/spec/lumberjack/attribute_formatter_spec.rb
+++ b/spec/lumberjack/attribute_formatter_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Lumberjack::AttributeFormatter do
       formatter_2.add_class(String) { |val| val.to_s.downcase }
       formatter_2.add_attribute(:foo) { |val| val.to_s.downcase }
 
-      expect(formatter_2.merge(formatter_1)).to eq formatter_2
+      expect(formatter_2.include(formatter_1)).to eq formatter_2
 
       expect(formatter_2.format("test" => "Test")).to eq("test" => "TEST")
       expect(formatter_2.format("pi" => 3.14)).to eq("pi" => 3.1)

--- a/spec/lumberjack/entry_formatter_spec.rb
+++ b/spec/lumberjack/entry_formatter_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Lumberjack::EntryFormatter do
         end
       end
 
-      expect(formatter_2.merge(formatter_1)).to eq formatter_2
+      expect(formatter_2.include(formatter_1)).to eq formatter_2
 
       message, attributes = formatter_2.format("foobar", {"status" => "new", "foo" => "bar"})
 

--- a/spec/lumberjack/formatter_spec.rb
+++ b/spec/lumberjack/formatter_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Lumberjack::Formatter do
       formatter_2.add(String) { |s| s.to_s.downcase }
       formatter_2.add(Integer, :multiply, 2)
 
-      expect(formatter_2.merge(formatter_1)).to eq formatter_2
+      expect(formatter_2.include(formatter_1)).to eq formatter_2
 
       expect(formatter_2.format("test")).to eq("TEST")
       expect(formatter_2.format(3.14)).to eq(3.1)


### PR DESCRIPTION
`include` provides better semantics than `merge`.