### PR TITLE
Revamp template with mustache syntax and severity options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Added `Lumberjack::Utils.current_line` as a helper method for getting the current line of code.
 - Added `Lumberjack.build_formatter` as a helper method for building entry formatters.
 - Added merge method on formatters to allow merging in formats from other formatters.
-- Templates can now use a left padded severity label with the option `pad_severity: true`. This will left pad the severity strings to five characters so that they can all be aligned in the log output.
+- Templates can now use variations on the severity label with a format option added to the placeholder: `{{severity(padded)}}`, `{{severity(char)}}`, `{{severity(emoji)}}`, and `{{severity(level)}}`.
+- Log entries in templates can now be colorized by severity with the `colorize: true`.
 - Added `Lumberjack::Formatter::Tags` for formatting attributes as "tags" in the logs. Arrays of values will be formatted as "[val1] [val2]" and hashes will be formatted as "[key1=value1] [key2=value2]".
 - Added `Lumberjack::FormatterRegistry` as a means of associating formatters with a symbol. Symbols can be used when adding class and attribute formatters. This extends the behavior previously limited to the built in formatters so that users can define their own formatters and register them for use.
 - Added `Lumberjack::DeviceRegistry` as a means for associating devices with a symbol. Symbols can then be passed to the constructor when creating a logger and the logger will take care of instantiating the device.
@@ -84,6 +85,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
   - `Lumberjack::Tags`
   - `Lumberjack::Formatter::TaggedMessage`
 - The Rails compatibility methods on `Lumberjack::Logger` (`tagged`, `silence`, `log_at`) have been moved to the [lumberjack_rails](https://github.com/bdurand/lumberjack_rails) gem. Installing that gem will restore these methods in a non-deprecated form.
+- Templates now use mustache syntax for placeholders instead of the colon prefix (i.e. `{{message}}` instead of `:message`). The `:tags` placeholder is also now called `{{attributes}}`.
 
 ## 1.4.1
 

--- a/README.md
+++ b/README.md
@@ -19,27 +19,33 @@ The philosophy behind the library is to promote use of structured logging with t
 
 ## Table of Contents
 
-1. [Usage](#usage)
-  - [Structured Logging With Attributes](#structured-logging-with-attributes)
-    - [Basic Attribute Logging](#basic-attribute-logging)
-    - [Adding attributes to the logger](#adding-attributes-to-the-logger)
-    - [Global Logger Attributes](#global-logger-attributes)
-    - [Nested Attributes and Complex Data](#nested-attributes-and-complex-data)
-    - [Attribute Inheritance and Merging](#attribute-inheritance-and-merging)
-    - [Using the tagged method](#using-the-tagged-method)
-  - [Context Isolation](#context-isolation)
-    - [Context Blocks](#context-blocks)
-    - [Nested Context Blocks](#nested-context-blocks)
-    - [Forking Loggers](#forking-loggers)
-  - [Formatters](#formatters)
-    - [Object Formatters](#object-formatters)
-    - [Attribute Formatters](#attribute-formatters)
-    - [Entry Formatter](#entry-formatter)
-  - [Devices and Templates](#devices-and-templates)
-  - [Testing Tools](#testing-tools)
-2. [Installation](#installation)
-3. [Contributing](#contributing)
-4. [License](#license)
+- [Usage](#usage)
+   - [Structured Logging With Attributes](#structured-logging-with-attributes)
+     - [Basic Attribute Logging](#basic-attribute-logging)
+     - [Adding attributes to the logger](#adding-attributes-to-the-logger)
+     - [Global Logger Attributes](#global-logger-attributes)
+     - [Nested Attributes and Complex Data](#nested-attributes-and-complex-data)
+     - [Attribute Inheritance and Merging](#attribute-inheritance-and-merging)
+     - [Using the tagged method](#using-the-tagged-method)
+   - [Context Isolation](#context-isolation)
+     - [Context Blocks](#context-blocks)
+     - [Nested Context Blocks](#nested-context-blocks)
+     - [Forking Loggers](#forking-loggers)
+   - [Formatters](#formatters)
+     - [Object Formatters](#object-formatters)
+     - [Attribute Formatters](#attribute-formatters)
+     - [Building An Entry Formatter](#building-an-entry-formatter)
+     - [Merging Formatters](#merging-formatters)
+   - [Devices and Templates](#devices-and-templates)
+     - [Built-in Devices](#built-in-devices)
+     - [Custom Devices](#custom-devices)
+     - [Templates](#templates)
+   - [Testing Utilities](#testing-utilities)
+   - [Using As A Stream](#using-as-a-stream)
+   - [Integrations](#integrations)
+- [Installation](#installation)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Usage
 
@@ -456,9 +462,9 @@ end
 
 You can also call `prepend` in which case any formats already defined will take precedence over the formats being included.
 
-### Output Devices
+### Devices and Templates
 
-Output devices control where and how log entries are written. Lumberjack provides a variety of built-in devices that can write to files, streams, multiple destinations, or serve special purposes like testing. All devices implement a common interface, making them interchangeable.
+Devices control where and how log entries are written. Lumberjack provides a variety of built-in devices that can write to files, streams, multiple destinations, or serve special purposes like testing. All devices implement a common interface, making them interchangeable.
 
 #### Built-in Devices
 
@@ -486,7 +492,7 @@ instantiate a multi device by passing in an array of values.
 
 ```ruby
 # Log to both file and STDOUT using the same template.
-logger = Lumberjack::Logger.new(["/var/log/app.log", $stdout], template: ":severity :message")
+logger = Lumberjack::Logger.new(["/var/log/app.log", $stdout], template: "{{severity}} {{message}}")
 
 logger.info("Application started")  # Appears in both file AND STDOUT
 ```
@@ -568,6 +574,70 @@ You can register a custom device with Lumberjack using the device registry. This
   # Now logger can be instantiated with the name and all options will be passed to
   # the MyDevice constructor.
   logger = Lumberjack::Logger.new(:my_device, autoflush: true)
+```
+
+#### Templates
+
+The output devices writing to a stream or file can define templates that format how log entries are written. Templates use mustache-style placeholders that are replaced with values from the log entry.
+
+##### Basic Template Usage
+
+```ruby
+# Simple template with common fields
+logger = Lumberjack::Logger.new(STDOUT, template: "{{time}} {{severity}} {{message}}")
+
+logger.info("Application started")
+# Output: 2025-09-03T14:30:15.123456 INFO Application started
+```
+
+##### Available Template Variables
+
+Templates support the following placeholder variables:
+
+| Variable | Description |
+|----------|-------------|
+| `time` | Log entry timestamp |
+| `severity` | Numeric severity level |
+| `progname` | Program name |
+| `pid` | Process ID |
+| `message` | Log message |
+| `attributes` | Formatted attributes |
+
+In addition you can put any attribute name in a placeholder. The attribute will be inserted in the log line where the placeholder is defined and will be removed from the general list of attributes.
+
+```ruby
+# The user_id attribute will appear separately on the log line from the
+# rest of the attributes.
+logger = Lumberjack::Logger.new(STDOUT,
+  template: "[{{time}} {{severity}} {{user_id}}] {{message}} {{attributes}}"
+)
+```
+
+The severity can also have an optional formatting argument added to it.
+
+| Variable | Description |
+|----------|-------------|
+| `severity` | Uppercase case severity label (INFO, WARN, etc.) |
+| `severity(padded)` | Severity label padded to 5 characters |
+| `severity(char)` | First character of severity label |
+| `severity(emoji)` | Emoji representation of severity level |
+| `severity(level)` | Numeric severity level |
+
+##### Template Options
+
+You can customize how template variables are formatted using template options:
+
+```ruby
+logger = Lumberjack::Logger.new(STDOUT,
+  template: "[{{time}} {{severity(padded)}} {{progname}}({{pid}})] [{{http.request_id}}] {{message}} {{attributes}}",
+  time_format: "%Y-%m-%d %H:%M:%S", # Custom time format
+  additional_lines: "\n> [{{http.request_id}}] {{message}}", # Template for additional lines on multiline messages
+  attribute_format: "%s=%s", # Format for attributes using printf syntax
+  colorize: true # Colorize log output according to entry severity
+)
+
+logger.info("Test message", user_id: 123, status: "active")
+# Output: 2025-09-03 14:30:15  INFO Test message user_id=123 | status=active
 ```
 
 ### Testing Utilities

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ logger.debug("Processing data",
 )
 ```
 
+> [!Note]
+> Attributes are passed in log statements in the little used `progname` argument that is defined in the standard Ruby Logger API. This attribute can be used to set a specific program name for the log entry that overrides the default program name on the logger.
+>
+> The only difference in the API is that Lumberjack loggers can take a Hash to set attributes. You can still pass a string to override the program name.
+
 #### Adding attributes to the logger
 
 Attributes added to the logger will be included in all log entries.

--- a/Rakefile
+++ b/Rakefile
@@ -68,3 +68,19 @@ namespace :profile do
     end.pretty_print
   end
 end
+
+namespace :colors do
+  desc "Print the color codes for each severity level"
+  task :print do
+    require_relative "lib/lumberjack"
+
+    logger = Lumberjack::Logger.new($stdout, level: :trace, template: "{{severity(emoji)}} {{severity(padded)}} {{message}}", colorize: true)
+    logger.trace("Test message")
+    logger.debug("Test message")
+    logger.info("Test message")
+    logger.warn("Test message")
+    logger.error("Test message")
+    logger.fatal("Test message")
+    logger.unknown("Test message")
+  end
+end

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -113,7 +113,7 @@ module Lumberjack
     end
 
     def context?
-      Utils.deprecated(:context?, "Use in_context? instead.") do
+      Utils.deprecated("Lumberjack.context?", "Lumberjack.context? is deprecated; use in_context? instead.") do
         in_context?
       end
     end
@@ -131,7 +131,7 @@ module Lumberjack
     # @return [Hash, nil]
     # @deprecated Use {.context_attributes}
     def context_tags
-      Utils.deprecated(:context_tags, "Use context_attributes instead.") do
+      Utils.deprecated("Lumberjack.context_tags", "Lumberjack.context_tags is deprecated; use context_attributes instead.") do
         context_attributes
       end
     end

--- a/lib/lumberjack/context_logger.rb
+++ b/lib/lumberjack/context_logger.rb
@@ -437,17 +437,6 @@ module Lumberjack
       merge_all_attributes || {}
     end
 
-    # Alias method for #attributes to provide backward compatibility with version 1.x API. This
-    # method will eventually be removed.
-    #
-    # @return [Hash]
-    # @deprecated Use {#attributes} instead
-    def tags
-      Utils.deprecated(:tags, "Use attributes instead.") do
-        attributes
-      end
-    end
-
     # Get the value of an attribute by name from the current context.
     #
     # @param name [String, Symbol] The name of the attribute to get.
@@ -455,17 +444,6 @@ module Lumberjack
     def attribute_value(name)
       name = name.join(".") if name.is_a?(Array)
       AttributesHelper.new(attributes)[name]
-    end
-
-    # Alias method for #attribute_value to provide backward compatibility with version 1.x API. This
-    # method will eventually be removed.
-    #
-    # @return [Hash]
-    # @deprecated Use {#attribute_value} instead
-    def tag_value(name)
-      Utils.deprecated(:tag_value, "Use attribute_value instead.") do
-        attribute_value(name)
-      end
     end
 
     # Remove all attributes on the current logger and logging context within a block.

--- a/lib/lumberjack/device/multi.rb
+++ b/lib/lumberjack/device/multi.rb
@@ -17,7 +17,7 @@ module Lumberjack
   #
   # @example Basic multi-device setup
   #   file_device = Lumberjack::Device::Writer.new("/var/log/app.log")
-  #   console_device = Lumberjack::Device::Writer.new(STDOUT, template: ":message")
+  #   console_device = Lumberjack::Device::Writer.new(STDOUT, template: "{{message}}")
   #   multi_device = Lumberjack::Device::Multi.new(file_device, console_device)
   class Device::Multi < Device
     attr_reader :devices

--- a/lib/lumberjack/device/writer.rb
+++ b/lib/lumberjack/device/writer.rb
@@ -50,6 +50,8 @@ module Lumberjack
     #
     # @option options [Boolean] :binmode (false) Whether to treat the stream as
     #   binary, skipping UTF-8 encoding conversion
+    #
+    # @option options [Boolean] :colorize (false) Whether to colorize log output
     def initialize(stream, options = {})
       @stream = stream
       @stream.sync = true if @stream.respond_to?(:sync=) && options[:autoflush] != false
@@ -57,7 +59,7 @@ module Lumberjack
       @binmode = options[:binmode]
 
       if options[:standard_logger_formatter]
-        @template = Template::StandardFormatterTemplate.new(options[:standard_logger_formatter], pad_severity: options[:pad_severity])
+        @template = Template::StandardFormatterTemplate.new(options[:standard_logger_formatter])
       else
         template = options[:template]
         @template = if template.respond_to?(:call)
@@ -68,7 +70,7 @@ module Lumberjack
             additional_lines: options[:additional_lines],
             time_format: options[:time_format],
             attribute_format: options[:attribute_format],
-            pad_severity: options[:pad_severity]
+            colorize: options[:colorize]
           )
         end
       end

--- a/lib/lumberjack/formatter.rb
+++ b/lib/lumberjack/formatter.rb
@@ -84,7 +84,7 @@ module Lumberjack
       # @return [Lumberjack::Formatter] A new formatter with no default mappings.
       # @deprecated Use #new instead.
       def empty
-        Utils.deprecated(:empty, "Use new instead.") do
+        Utils.deprecated("Formatter.empty", "Lumberjack::Formatter.empty is deprecated; use new instead.") do
           new
         end
       end

--- a/lib/lumberjack/log_entry.rb
+++ b/lib/lumberjack/log_entry.rb
@@ -48,8 +48,13 @@ module Lumberjack
     # Get the human-readable severity label corresponding to the numeric severity level.
     #
     # @return [String] The severity label (DEBUG, INFO, WARN, ERROR, FATAL, or UNKNOWN)
-    def severity_label(pad = false)
-      Severity.level_to_label(severity, pad)
+    def severity_label
+      severity_data.label
+    end
+
+    # Get the data corresponding to the severity. This include variations on the severity label.
+    def severity_data
+      Severity.data(severity)
     end
 
     # Generate a formatted string representation of the log entry suitable for
@@ -91,7 +96,7 @@ module Lumberjack
     # @return [Hash, nil] The attributes of the log entry.
     # @deprecated Use {#attributes} instead.
     def tags
-      Utils.deprecated(:tags, "Use attributes instead.") do
+      Utils.deprecated("LogEntry#tags", "Lumberjack::LogEntry#tags is deprecated; use attributes instead.") do
         attributes
       end
     end
@@ -111,7 +116,7 @@ module Lumberjack
     # @return [Hash]
     # @deprecated Use {#[]} instead.
     def tag(name)
-      Utils.deprecated(:tag, "Use [] instead.") do
+      Utils.deprecated("LogEntry#tag", "Lumberjack::LogEntry#tag is deprecated; use [] instead.") do
         self[name]
       end
     end
@@ -131,7 +136,7 @@ module Lumberjack
     # @return [Hash]
     # @deprecated Use {#nested_attributes} instead.
     def nested_tags
-      Utils.deprecated(:nested_tags, "Use nested_attributes instead.") do
+      Utils.deprecated("LogEntry#nested_tags", "Lumberjack::LogEntry#nested_tags is deprecated; use nested_attributes instead.") do
         nested_attributes
       end
     end

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -34,7 +34,7 @@ module Lumberjack
   #
   # @example Using different devices
   #   logger = Lumberjack::Logger.new("logs/application.log")  # Log to file
-  #   logger = Lumberjack::Logger.new(STDOUT, template: ":severity - :message")  # Log to a stream with a template
+  #   logger = Lumberjack::Logger.new(STDOUT, template: "{{severity}} - {{message}}")  # Log to a stream with a template
   #   logger = Lumberjack::Logger.new(:test)  # Log to a buffer for testing
   #   logger = Lumberjack::Logger.new(another_logger) # Proxy logs to another logger
   #   logger = Lumberjack::Logger.new(MyDevice.new)  # Log to a custom Lumberjack::Device
@@ -103,19 +103,19 @@ module Lumberjack
       device_options[:standard_logger_formatter] = formatter if standard_logger_formatter?(formatter)
 
       if device_options.include?(:tag_formatter)
-        Utils.deprecated(:tag_formatter, "Use attribute_formatter instead.") do
+        Utils.deprecated("Logger.options(:tag_formatter)", "Lumberjack::Logger :tag_formatter option is deprecated; use :attribute_formatter instead.") do
           attribute_formatter ||= device_options.delete(:tag_formatter)
         end
       end
 
       if device_options.include?(:roll) && shift_age != 0
-        Utils.deprecated(:roll, "Use shift_age instead.") do
+        Utils.deprecated("Logger.options(:roll)", "Lumberjack::Logger :roll option is deprecated; use the shift_age argument instead.") do
           shift_age = device_options.delete(:roll)
         end
       end
 
       if device_options.include?(:max_size)
-        Utils.deprecated(:max_size, "Use shift_size instead.") do
+        Utils.deprecated("Logger.options(:max_size)", "Lumberjack::Logger :max_size option is deprecated; use the shift_size argument instead.") do
           shift_age = 10
           shift_size = device_options.delete(:max_size)
         end
@@ -206,14 +206,14 @@ module Lumberjack
 
     # @deprecated Use {#attribute_formatter} instead.
     def tag_formatter
-      Utils.deprecated(:tag_formatter, "Use attribute_formatter instead.") do
+      Utils.deprecated("Logger#tag_formatter", "Lumberjack::Logger#tag_formatter is deprecated; use attribute_formatter instead.") do
         formatter.attributes.attribute_formatter
       end
     end
 
     # @deprecated Use {#attribute_formatter=} instead.
     def tag_formatter=(value)
-      Utils.deprecated(:tag_formatter=, "Use attribute_formatter= instead.") do
+      Utils.deprecated("Logger#tag_formatter=", "Lumberjack::Logger#tag_formatter= is deprecated; use attribute_formatter= instead.") do
         formatter.attributes.attribute_formatter = value
       end
     end
@@ -257,7 +257,7 @@ module Lumberjack
     # @return [void]
     # @deprecated Use with_progname or progname= instead.
     def set_progname(value, &block)
-      Utils.deprecated(:set_progname, "Use with_progname or progname= instead.") do
+      Utils.deprecated("Logger#set_progname", "Lumberjack::Logger#set_progname is deprecated; use with_progname or progname= instead.") do
         if block
           with_progname(value, &block)
         else
@@ -266,12 +266,34 @@ module Lumberjack
       end
     end
 
+    # Alias method for #attributes to provide backward compatibility with version 1.x API. This
+    # method will eventually be removed.
+    #
+    # @return [Hash]
+    # @deprecated Use {#attributes} instead
+    def tags
+      Utils.deprecated("Logger#tags", "Lumberjack::Logger#tags is deprecated; use attributes instead.") do
+        attributes
+      end
+    end
+
+    # Alias method for #attribute_value to provide backward compatibility with version 1.x API. This
+    # method will eventually be removed.
+    #
+    # @return [Hash]
+    # @deprecated Use {#attribute_value} instead
+    def tag_value(name)
+      Utils.deprecated("Logger#tag_value", "Lumberjack::Logger#tag_value is deprecated; use attribute_value instead.") do
+        attribute_value(name)
+      end
+    end
+
     # Use tag! instead
     #
     # @return [void]
     # @deprecated Use {#tag!} instead.
     def tag_globally(tags)
-      Utils.deprecated(:tag_globally, "Use tag! instead.") do
+      Utils.deprecated("Logger#tag_globally", "Lumberjack::Logger#tag_globally is deprecated; use tag! instead.") do
         tag!(tags)
       end
     end
@@ -281,7 +303,7 @@ module Lumberjack
     # @return [Boolean]
     # @deprecated Use {#in_context?} instead.
     def in_tag_context?
-      Utils.deprecated(:in_tag_context?, "Use context? instead.") do
+      Utils.deprecated("Logger#in_tag_context?", "Lumberjack::Logger#in_tag_context? is deprecated; use in_context? instead.") do
         context?
       end
     end
@@ -294,7 +316,7 @@ module Lumberjack
     # @return [void]
     # @deprecated Use untag or untag! instead.
     def remove_tag(*tag_names)
-      Utils.deprecated(:remove_tag, "Use untag or untag! instead.") do
+      Utils.deprecated("Logger#remove_tag", "Lumberjack::Logger#remove_tag is deprecated; use untag or untag! instead.") do
         attributes = current_context&.attributes
         AttributesHelper.new(attributes).delete(*tag_names) if attributes
       end
@@ -308,7 +330,7 @@ module Lumberjack
     # @deprecated This implementation is deprecated. Install the lumberjack_rails gem for full support.
     def tagged(*tags, &block)
       deprecation_message = "Install the lumberjack_rails gem for full support of the tagged method."
-      Utils.deprecated(:tagged, deprecation_message) do
+      Utils.deprecated("Logger#tagged", deprecation_message) do
         append_to(:tagged, *tags, &block)
       end
     end
@@ -318,7 +340,7 @@ module Lumberjack
     # @see clear_attributes
     # @deprecated Use clear_attributes instead.
     def untagged(&block)
-      Utils.deprecated(:untagged, "Use clear_attributes instead.") do
+      Utils.deprecated("Logger#untagged", "Lumberjack::Logger#untagged is deprecated; use clear_attributes instead.") do
         clear_attributes(&block)
       end
     end
@@ -330,7 +352,7 @@ module Lumberjack
     # @deprecated This implementation is deprecated. Install the lumberjack_rails gem for full support.
     def log_at(level, &block)
       deprecation_message = "Install the lumberjack_rails gem for full support of the log_at method."
-      Utils.deprecated(:log_at, deprecation_message) do
+      Utils.deprecated("Logger#log_at", deprecation_message) do
         with_level(level, &block)
       end
     end
@@ -342,7 +364,7 @@ module Lumberjack
     # @deprecated This implementation is deprecated. Install the lumberjack_rails gem for full support.
     def silence(level = Logger::ERROR, &block)
       deprecation_message = "Install the lumberjack_rails gem for full support of the silence method."
-      Utils.deprecated(:silence, deprecation_message) do
+      Utils.deprecated("Logger#silence", deprecation_message) do
         with_level(level, &block)
       end
     end

--- a/lib/lumberjack/severity.rb
+++ b/lib/lumberjack/severity.rb
@@ -16,20 +16,38 @@ module Lumberjack
     SEVERITY_LABELS = %w[TRACE DEBUG INFO WARN ERROR FATAL ANY].freeze
     private_constant :SEVERITY_LABELS
 
-    PADDED_SEVERITY_LABELS = SEVERITY_LABELS.map { |label| label.ljust(5) }.freeze
-    private_constant :PADDED_SEVERITY_LABELS
+    # Data object for severity levels that includes variations on the label.
+    class Data
+      attr_reader :level, :label, :padded_label, :char, :emoji, :terminal_color
+
+      def initialize(level, label, emoji, terminal_color)
+        @level = level
+        @label = label.freeze
+        @padded_label = label.ljust(5).freeze
+        @char = label[0].freeze
+        @emoji = emoji.freeze
+        @terminal_color = "\e[38;5;#{terminal_color}m"
+      end
+    end
+
+    SEVERITIES = [
+      Data.new(TRACE, "TRACE", "🔍", 247).freeze,
+      Data.new(DEBUG, "DEBUG", "🐞", 244).freeze,
+      Data.new(INFO, "INFO", "🔵", 33).freeze,
+      Data.new(WARN, "WARN", "🟡", 208).freeze,
+      Data.new(ERROR, "ERROR", "❌", 9).freeze,
+      Data.new(FATAL, "FATAL", "🔥", 160).freeze,
+      Data.new(UNKNOWN, "ANY", "❓", 129).freeze
+    ].freeze
+    private_constant :SEVERITIES
 
     class << self
       # Convert a severity level to a label.
       #
       # @param severity [Integer] The severity level to convert.
       # @return [String] The severity label.
-      def level_to_label(severity, padded = false)
-        if padded
-          PADDED_SEVERITY_LABELS[severity + 1] || PADDED_SEVERITY_LABELS.last
-        else
-          SEVERITY_LABELS[severity + 1] || SEVERITY_LABELS.last
-        end
+      def level_to_label(severity)
+        SEVERITIES[severity + 1]&.label || SEVERITIES.last.label
       end
 
       # Convert a severity label to a level.
@@ -51,6 +69,14 @@ module Lumberjack
         else
           label_to_level(value)
         end
+      end
+
+      # Return a data object that maps the severity level to variations on the label.
+      #
+      # @param level [Integer, String, Symbol] The severity level.
+      # @return [SeverityData] The severity data object.
+      def data(level)
+        SEVERITIES[coerce(level) + 1] || SEVERITIES.last
       end
     end
   end

--- a/lib/lumberjack/tags.rb
+++ b/lib/lumberjack/tags.rb
@@ -10,7 +10,7 @@ module Lumberjack
       # @return [Hash] The hash with string keys.
       # @deprecated No longer supported
       def stringify_keys(hash)
-        Utils.deprecated(:stringify_keys, "No longer supported") do
+        Utils.deprecated("Lumberjack::Tags.stringify_keys", "Lumberjack::Tags.stringify_keys is no longer supported") do
           return nil if hash.nil?
           if hash.keys.all? { |key| key.is_a?(String) }
             hash
@@ -26,7 +26,7 @@ module Lumberjack
       # @return [Hash] The hash with string keys and expanded values.
       # @deprecated Use {Lumberjack::AttributesHelper.expand_runtime_values} instead.
       def expand_runtime_values(hash)
-        Utils.deprecated(:expand_runtime_values, "Use Lumberjack::AttributesHelper.expand_runtime_values instead.") do
+        Utils.deprecated("Lumberjack::Tags.expand_runtime_values", "Lumberjack::Tags.expand_runtime_values is deprecated; use Lumberjack::AttributesHelper.expand_runtime_values instead.") do
           AttributesHelper.expand_runtime_values(hash)
         end
       end

--- a/lib/lumberjack/template.rb
+++ b/lib/lumberjack/template.rb
@@ -6,22 +6,28 @@ module Lumberjack
   # with support for all log entry components and custom attributes.
   #
   # The template system supports the following built-in placeholders:
-  # * `{{time}}` - The log entry timestamp
-  # * `{{severity}}` - The severity level (DEBUG, INFO, WARN, ERROR, FATAL). The severity
-  #   can also be formatted in a variety of ways with an optional format specifier.
-  #   Supported formats include:
-  #   * `{{severity(padded)}}` - Left-padded to five characters
-  #   * `{{severity(char)}}` - Single character representation
-  #   * `{{severity(emoji)}}` - Emoji representation
-  #   * `{{severity(level)}}` - Numeric level representation
-  # * `{{progname}}` - The program name that generated the entry
-  # * `{{pid}}` - The process ID
-  # * `{{message}}` - The main log message content
-  # * `{{attributes}}` - All custom attributes formatted as key:value pairs
   #
-  # Custom attribute placeholders can be created using `{{attribute_name}}` syntax. Any
-  # attributes explicitly added to the template will be removed from the general
-  # {{attributes}} placeholder.
+  # @example
+  #   * `{{time}}` - The log entry timestamp
+  #   * `{{severity}}` - The severity level (DEBUG, INFO, WARN, ERROR, FATAL). The severity
+  #     can also be formatted in a variety of ways with an optional format specifier.
+  #     Supported formats include:
+  #     * `{{severity(padded)}}` - Left-padded to five characters
+  #     * `{{severity(char)}}` - Single character representation
+  #     * `{{severity(emoji)}}` - Emoji representation
+  #     * `{{severity(level)}}` - Numeric level representation
+  #   * `{{progname}}` - The program name that generated the entry
+  #   * `{{pid}}` - The process ID
+  #   * `{{message}}` - The main log message content
+  #   * `{{attributes}}` - All custom attributes formatted as key:value pairs
+  #
+  # Custom attribute placeholders can also be put in the double bracket placeholders.
+  # Any attributes explicitly added to the template in their own placeholder will be removed
+  # from the general list of attributes.
+  #
+  # @example
+  #   # The user_id attribute will be put before the message.
+  #   template = Lumberjack::Template.new("[{{time}} {{severity}}] (usr:{{user_id}} {{message}} -- {{attributes}})")
   #
   # @example Basic template usage
   #   template = Lumberjack::Template.new("[{{time}} {{severity}}] {{message}}")
@@ -112,15 +118,16 @@ module Lumberjack
     # custom time formatting, and configurable attribute display.
     #
     # @param first_line [String, nil] Template for formatting the first line of messages.
-    #   Defaults to "[{{time}} {{severity(padded)}} {{progname}}({{pid}})] {{message}} {{attributes}}"
+    #   Defaults to `[time severity(padded) progname(pid)] message attributes`
     # @param additional_lines [String, nil] Template for formatting additional lines
-    #   in multi-line messages. Defaults to "\n> {{message}}"
+    #   in multi-line messages. Defaults to `\n> message`
     # @param time_format [String, Symbol, nil] Time formatting specification. Can be:
     #   - A strftime format string (e.g., "%Y-%m-%d %H:%M:%S")
     #   - `:milliseconds` for ISO format with millisecond precision (default)
     #   - `:microseconds` for ISO format with microsecond precision
     # @param attribute_format [String, nil] Printf-style format for individual attributes.
     #   Must contain exactly two %s placeholders for name and value. Defaults to "[%s:%s]"
+    # @param colorize [Boolean] Whether to colorize the log entry based on severity (default: false)
     # @raise [ArgumentError] If attribute_format doesn't contain exactly two %s placeholders
     def initialize(first_line = nil, additional_lines: nil, time_format: nil, attribute_format: nil, colorize: false)
       first_line ||= DEFAULT_FIRST_LINE_TEMPLATE

--- a/lib/lumberjack/template.rb
+++ b/lib/lumberjack/template.rb
@@ -6,32 +6,35 @@ module Lumberjack
   # with support for all log entry components and custom attributes.
   #
   # The template system supports the following built-in placeholders:
-  # * `:time` - The log entry timestamp
-  # * `:severity` - The severity level (DEBUG, INFO, WARN, ERROR, FATAL)
-  # * `:progname` - The program name that generated the entry
-  # * `:pid` - The process ID
-  # * `:message` - The main log message content
-  # * `:attributes` - All custom attributes formatted as key:value pairs
+  # * `{{time}}` - The log entry timestamp
+  # * `{{severity}}` - The severity level (DEBUG, INFO, WARN, ERROR, FATAL). The severity
+  #   can also be formatted in a variety of ways with an optional format specifier.
+  #   Supported formats include:
+  #   * `{{severity(padded)}}` - Left-padded to five characters
+  #   * `{{severity(char)}}` - Single character representation
+  #   * `{{severity(emoji)}}` - Emoji representation
+  #   * `{{severity(level)}}` - Numeric level representation
+  # * `{{progname}}` - The program name that generated the entry
+  # * `{{pid}}` - The process ID
+  # * `{{message}}` - The main log message content
+  # * `{{attributes}}` - All custom attributes formatted as key:value pairs
   #
-  # Custom attribute placeholders can be created using `:attribute_name` syntax.
-  # For attribute names containing special characters, use curly bracket notation:
-  # `:{ http.request-id }` or `:{ user-agent }`.
-  #
-  # The `:tag` placeholder is supported for backward compatibility with version 1.x
-  # and functions identically to `:attributes`.
+  # Custom attribute placeholders can be created using `{{attribute_name}}` syntax. Any
+  # attributes explicitly added to the template will be removed from the general
+  # {{attributes}} placeholder.
   #
   # @example Basic template usage
-  #   template = Lumberjack::Template.new("[:time :severity] :message")
+  #   template = Lumberjack::Template.new("[{{time}} {{severity}}] {{message}}")
   #   # Output: [2023-08-21T10:30:15.123 INFO] User logged in
   #
   # @example Template with custom attributes
-  #   template = Lumberjack::Template.new("[:time :severity :user_id] :message")
+  #   template = Lumberjack::Template.new("[{{time}} {{severity}} {{user_id}}] {{message}}")
   #   # Output: [2023-08-21T10:30:15.123 INFO 12345] User action completed
   #
   # @example Multi-line message formatting
   #   template = Lumberjack::Template.new(
-  #     "[:time :severity] :message",
-  #     additional_lines: "\n    | :message"
+  #     "[{{time}} {{severity}}] {{message}}",
+  #     additional_lines: "\n    | {{message}}"
   #   )
   #   # Output:
   #   # [2023-08-21T10:30:15.123 INFO] First line
@@ -40,13 +43,13 @@ module Lumberjack
   #
   # @example Custom time formatting
   #   template = Lumberjack::Template.new(
-  #     "[:time :severity] :message",
+  #     "[{{time}} {{severity}}] {{message}}",
   #     time_format: "%Y-%m-%d %H:%M:%S"
   #   )
   #   # Output: [2023-08-21 10:30:15 INFO] Message content
   class Template
-    DEFAULT_FIRST_LINE_TEMPLATE = "[:time :severity :progname(:pid)] :message :attributes"
-    DEFAULT_ADDITIONAL_LINES_TEMPLATE = "#{Lumberjack::LINE_SEPARATOR}> :message"
+    DEFAULT_FIRST_LINE_TEMPLATE = "[{{time}} {{severity(padded)}} {{progname}}({{pid}})] {{message}} {{attributes}}"
+    DEFAULT_ADDITIONAL_LINES_TEMPLATE = "#{Lumberjack::LINE_SEPARATOR}> {{message}}"
     DEFAULT_ATTRIBUTE_FORMAT = "[%s:%s]"
 
     # A wrapper template that delegates formatting to a standard Ruby Logger formatter.
@@ -56,9 +59,8 @@ module Lumberjack
       # Create a new wrapper for a standard Ruby Logger formatter.
       #
       # @param formatter [Logger::Formatter] The formatter to wrap
-      def initialize(formatter, pad_severity: false)
+      def initialize(formatter)
         @formatter = formatter
-        @pad_severity = pad_severity
       end
 
       # Format a log entry using the wrapped formatter.
@@ -66,7 +68,7 @@ module Lumberjack
       # @param entry [Lumberjack::LogEntry] The log entry to format
       # @return [String] The formatted log entry
       def call(entry)
-        @formatter.call(entry.severity_label(@pad_severity), entry.time, entry.progname, entry.message)
+        @formatter.call(entry.severity_label, entry.time, entry.progname, entry.message)
       end
 
       # Set the datetime format on the wrapped formatter if supported.
@@ -85,34 +87,60 @@ module Lumberjack
       end
     end
 
-    TEMPLATE_ARGUMENT_ORDER = %w[:time :severity :progname :pid :message :attributes].freeze
+    TEMPLATE_ARGUMENT_ORDER = %w[
+      time
+      severity
+      severity(padded)
+      severity(char)
+      severity(emoji)
+      severity(level)
+      progname
+      pid
+      message
+      attributes
+    ].freeze
+
     MILLISECOND_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%3N"
     MICROSECOND_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%6N"
-    PLACEHOLDER_PATTERN = /:(([a-z0-9_]+)|({[^}]+}))/i
-    private_constant :TEMPLATE_ARGUMENT_ORDER, :MILLISECOND_TIME_FORMAT, :MICROSECOND_TIME_FORMAT, :PLACEHOLDER_PATTERN
+    PLACEHOLDER_PATTERN = /{{ *((?:[^}]|}(?!}))*) *}}/i
+    V1_PLACEHOLDER_PATTERN = /:[a-z0-9_.-]+/i
+    RESET_CHAR = "\e[0m"
+    private_constant :TEMPLATE_ARGUMENT_ORDER, :MILLISECOND_TIME_FORMAT, :MICROSECOND_TIME_FORMAT, :PLACEHOLDER_PATTERN, :V1_PLACEHOLDER_PATTERN, :RESET_CHAR
 
     # Create a new template with customizable formatting options. The template
     # supports different formatting for single-line and multi-line messages,
     # custom time formatting, and configurable attribute display.
     #
-    # @param first_line [String] Template for formatting the first line of messages.
-    #   Defaults to "[:time :severity :progname(:pid)] :message :attributes"
+    # @param first_line [String, nil] Template for formatting the first line of messages.
+    #   Defaults to "[{{time}} {{severity(padded)}} {{progname}}({{pid}})] {{message}} {{attributes}}"
     # @param additional_lines [String, nil] Template for formatting additional lines
-    #   in multi-line messages. Defaults to "\n> :message"
+    #   in multi-line messages. Defaults to "\n> {{message}}"
     # @param time_format [String, Symbol, nil] Time formatting specification. Can be:
     #   - A strftime format string (e.g., "%Y-%m-%d %H:%M:%S")
     #   - `:milliseconds` for ISO format with millisecond precision (default)
     #   - `:microseconds` for ISO format with microsecond precision
     # @param attribute_format [String, nil] Printf-style format for individual attributes.
     #   Must contain exactly two %s placeholders for name and value. Defaults to "[%s:%s]"
-    # @param pad_severity [Boolean] Whether to pad the severity label to a fixed width.
     # @raise [ArgumentError] If attribute_format doesn't contain exactly two %s placeholders
-    def initialize(first_line, additional_lines: nil, time_format: nil, attribute_format: nil, pad_severity: false)
+    def initialize(first_line = nil, additional_lines: nil, time_format: nil, attribute_format: nil, colorize: false)
       first_line ||= DEFAULT_FIRST_LINE_TEMPLATE
-      @first_line_template, @first_line_attributes = compile("#{first_line.chomp}#{Lumberjack::LINE_SEPARATOR}")
+      first_line = "#{first_line.chomp}#{Lumberjack::LINE_SEPARATOR}"
+      if !first_line.include?("{{") && first_line.match?(V1_PLACEHOLDER_PATTERN)
+        Utils.deprecated("Template.v1", "Templates now use {{placeholder}} instead of :placeholder and :tags has been replaced with {{attributes}}.") do
+          @first_line_template, @first_line_attributes = compile_v1(first_line)
+        end
+      else
+        @first_line_template, @first_line_attributes = compile(first_line)
+      end
 
       additional_lines ||= DEFAULT_ADDITIONAL_LINES_TEMPLATE
-      @additional_line_template, @additional_line_attributes = compile(additional_lines)
+      if !additional_lines.include?("{{") && additional_lines.match?(V1_PLACEHOLDER_PATTERN)
+        Utils.deprecated("Template.v1", "Templates now use {{placeholder}} instead of :placeholder and :tags has been replaced with {{attributes}}.") do
+          @additional_line_template, @additional_line_attributes = compile_v1(additional_lines)
+        end
+      else
+        @additional_line_template, @additional_line_attributes = compile(additional_lines)
+      end
 
       @attribute_template = attribute_format || DEFAULT_ATTRIBUTE_FORMAT
       unless @attribute_template.scan("%s").size == 2
@@ -120,10 +148,10 @@ module Lumberjack
       end
 
       # Formatting the time is relatively expensive, so only do it if it will be used
-      @template_include_time = first_line.include?(":time") || additional_lines.include?(":time")
+      @template_include_time = "#{@first_line_template} #{@additional_line_template}".include?("%1$s")
       self.datetime_format = (time_format || :milliseconds)
 
-      @pad_severity = pad_severity
+      @colorize = colorize
     end
 
     # Set the datetime format used for timestamp formatting in the template.
@@ -167,12 +195,23 @@ module Lumberjack
       end
 
       formatted_time = @time_formatter.call(entry.time) if @template_include_time
-      format_args = [formatted_time, entry.severity_label(@pad_severity), entry.progname, entry.pid, first_line]
+      severity = entry.severity_data
+      format_args = [
+        formatted_time,
+        severity.label,
+        severity.padded_label,
+        severity.char,
+        severity.emoji,
+        severity.level,
+        entry.progname,
+        entry.pid,
+        first_line
+      ]
       append_attribute_args!(format_args, entry.attributes, @first_line_attributes)
       message = (@first_line_template % format_args)
 
       if additional_lines && !additional_lines.empty?
-        format_args.slice!(5, format_args.size)
+        format_args.slice!(9, format_args.size)
         append_attribute_args!(format_args, entry.attributes, @additional_line_attributes)
 
         message_length = message.length
@@ -180,13 +219,16 @@ module Lumberjack
         chomped = message.length != message_length
 
         additional_lines.each do |line|
-          format_args[4] = line
+          format_args[8] = line
           line_message = @additional_line_template % format_args
           message << line_message
         end
 
         message << Lumberjack::LINE_SEPARATOR if chomped
       end
+
+      message = colorize_entry(message, entry) if @colorize
+
       message
     end
 
@@ -229,22 +271,52 @@ module Lumberjack
     # @param template [String] The raw template string with placeholders
     # @return [Array<String, Array<String>>] A tuple of [compiled_template, attribute_vars]
     def compile(template) # :nodoc:
-      template = template.gsub(/:({ *)?tags(?: *})?\b/, ":\\1attributes") unless template.include?(":attributes")
-      template = template.gsub(/ :({ *)?attributes\b/, ":\\1attributes")
+      template = template.gsub(/ ({{ *)attributes( *}})/, "\\1attributes\\2")
       template = template.gsub(/%(?!%)/, "%%")
 
       attribute_vars = []
       template = template.gsub(PLACEHOLDER_PATTERN) do |match|
-        var_name = match.sub(/{ */, "").sub(/ *}/, "")
+        var_name = match.sub(/{{ */, "").sub(/ *}}/, "")
         position = TEMPLATE_ARGUMENT_ORDER.index(var_name)
         if position
           "%#{position + 1}$s"
         else
-          attribute_vars << var_name[1, var_name.length]
+          attribute_vars << var_name
           "%#{TEMPLATE_ARGUMENT_ORDER.size + attribute_vars.size}$s"
         end
       end
       [template, attribute_vars]
+    end
+
+    # Parse and compile a template string into a sprintf-compatible format string
+    # and extract attribute variable names. This method handles placeholder
+    # substitution and escape sequence processing.
+    #
+    # @param template [String] The raw template string with placeholders
+    # @return [Array<String, Array<String>>] A tuple of [compiled_template, attribute_vars]
+    def compile_v1(template) # :nodoc:
+      template = template.gsub(":tags", ":attributes").gsub(/ ?:attributes/, ":attributes")
+      template = template.gsub(/%(?!%)/, "%%")
+
+      attribute_vars = []
+      template = template.gsub(V1_PLACEHOLDER_PATTERN) do |match|
+        var_name = match[1, match.length]
+        position = TEMPLATE_ARGUMENT_ORDER.index(var_name)
+        if position
+          "%#{position + 1}$s"
+        else
+          attribute_vars << var_name
+          "%#{TEMPLATE_ARGUMENT_ORDER.size + attribute_vars.size}$s"
+        end
+      end
+      [template, attribute_vars]
+    end
+
+    def colorize_entry(formatted_string, entry)
+      color_start = entry.severity_data.terminal_color
+      formatted_string.split(Lumberjack::LINE_SEPARATOR).collect do |line|
+        "#{color_start}#{line}#{RESET_CHAR}"
+      end.join(Lumberjack::LINE_SEPARATOR)
     end
   end
 end

--- a/lib/lumberjack/utils.rb
+++ b/lib/lumberjack/utils.rb
@@ -184,7 +184,7 @@ module Lumberjack
       # @return [Hash<String, Object>] The flattened hash.
       # @deprecated Use {.flatten_attributes} instead.
       def flatten_tags(tag_hash)
-        Utils.deprecated(:flatten_tags, "Use flatten_attributes instead.") do
+        Utils.deprecated("Lumberjack::Utils.flatten_tags", "Lumberjack::Utils.flatten_tags is deprecated; use flatten_attributes instead.") do
           flatten_attributes(tag_hash)
         end
       end
@@ -223,7 +223,7 @@ module Lumberjack
       # @return [Hash] The expanded hash.
       # @deprecated Use {.expand_attributes} instead.
       def expand_tags(tags)
-        Utils.deprecated(:expand_tags, "Use expand_attributes instead.") do
+        Utils.deprecated("Lumberjack::Utils.expand_tags", "Lumberjack::Utils.expand_tags is deprecated; use expand_attributes instead.") do
           expand_attributes(tags)
         end
       end

--- a/spec/lumberjack/device/logger_file_spec.rb
+++ b/spec/lumberjack/device/logger_file_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Lumberjack::Device::LoggerFile do
   let(:out) { StringIO.new }
 
   it "wraps a ::Logger::LogDevice" do
-    device = Lumberjack::Device::LoggerFile.new(out, template: ":severity :message")
+    device = Lumberjack::Device::LoggerFile.new(out, template: "{{severity}} {{message}}")
     expect(device.class).to eq(Lumberjack::Device::LoggerFile)
     device.write(Lumberjack::LogEntry.new(Time.now, Logger::INFO, "Test message", nil, Process.pid, nil))
     expect(out.string.chomp).to eq("INFO Test message")
@@ -14,7 +14,7 @@ RSpec.describe Lumberjack::Device::LoggerFile do
 
   it "passes supported device options through to the underlying device" do
     expect(Logger::LogDevice).to receive(:new).with(out, shift_age: 10).and_call_original
-    Lumberjack::Device::LoggerFile.new(out, template: ":severity :message", shift_age: 10)
+    Lumberjack::Device::LoggerFile.new(out, template: "{{severity}} {{message}}", shift_age: 10)
   end
 
   it "exposes the file path for the underlying stream" do

--- a/spec/lumberjack/device/multi_spec.rb
+++ b/spec/lumberjack/device/multi_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 RSpec.describe Lumberjack::Device::Multi do
   let(:output_1) { StringIO.new }
   let(:output_2) { StringIO.new }
-  let(:device_1) { Lumberjack::Device::Writer.new(output_1, template: ":message") }
-  let(:device_2) { Lumberjack::Device::Writer.new(output_2, template: ":severity - :message") }
+  let(:device_1) { Lumberjack::Device::Writer.new(output_1, template: "{{message}}") }
+  let(:device_2) { Lumberjack::Device::Writer.new(output_2, template: "{{severity}} - {{message}}") }
   let(:device) { Lumberjack::Device::Multi.new(device_1, device_2) }
 
   let(:entry) { Lumberjack::LogEntry.new(Time.now, Logger::INFO, "test", "app", 100, {}) }

--- a/spec/lumberjack/log_entry_spec.rb
+++ b/spec/lumberjack/log_entry_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Lumberjack::LogEntry do
       expect(Lumberjack::LogEntry.new(Time.now, Logger::FATAL, "test", "app", 1500, nil).severity_label).to eq("FATAL")
       expect(Lumberjack::LogEntry.new(Time.now, -100, "test", "app", 1500, nil).severity_label).to eq("ANY")
       expect(Lumberjack::LogEntry.new(Time.now, 1000, "test", "app", 1500, nil).severity_label).to eq("ANY")
-      expect(Lumberjack::LogEntry.new(Time.now, Logger::INFO, "test", "app", 1500, nil).severity_label(true)).to eq("INFO ")
     end
 
     it "should have a message" do
@@ -54,6 +53,13 @@ RSpec.describe Lumberjack::LogEntry do
       expect(entry.pid).to eq(1500)
       entry.pid = 150
       expect(entry.pid).to eq(150)
+    end
+  end
+
+  describe "#severity_data" do
+    it "returns the severity data object" do
+      entry = Lumberjack::LogEntry.new(Time.now, Logger::INFO, "test", "app", 1500, "foo" => "ABCD")
+      expect(entry.severity_data).to eq(Lumberjack::Severity.data(Logger::INFO))
     end
   end
 

--- a/spec/lumberjack/logger_spec.rb
+++ b/spec/lumberjack/logger_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Lumberjack::Logger do
 
     it "should only affect the current fiber when changing the progname in a block" do
       out = StringIO.new
-      logger = Lumberjack::Logger.new(out, progname: "thread1", template: ":progname :message")
+      logger = Lumberjack::Logger.new(out, progname: "thread1", template: "{{progname}} {{message}}")
       Fiber.new do
         logger.set_progname("fiber1") do
           expect(logger.progname).to eq("fiber1")
@@ -215,7 +215,7 @@ RSpec.describe Lumberjack::Logger do
   describe "#datetime_format" do
     it "should be able to set the datetime format for timestamps on the log device" do
       out = StringIO.new
-      logger = Lumberjack::Logger.new(out, template: ":time :message", datetime_format: "%Y-%m-%d")
+      logger = Lumberjack::Logger.new(out, template: "{{time}} {{message}}", datetime_format: "%Y-%m-%d")
       expect(logger.datetime_format).to eq "%Y-%m-%d"
       Timecop.freeze do
         logger.info("one")
@@ -262,7 +262,7 @@ RSpec.describe Lumberjack::Logger do
   describe "#close" do
     it "should close the device" do
       out = StringIO.new
-      logger = Lumberjack::Logger.new(out, level: Logger::INFO, template: ":message")
+      logger = Lumberjack::Logger.new(out, level: Logger::INFO, template: "{{message}}")
       expect(logger.device).to receive(:flush).at_least(:once)
       expect(logger.closed?).to eq false
       logger.close
@@ -274,7 +274,7 @@ RSpec.describe Lumberjack::Logger do
   describe "#reopen" do
     it "should reopen the devices" do
       out = StringIO.new
-      logger = Lumberjack::Logger.new(out, level: Logger::INFO, template: ":message")
+      logger = Lumberjack::Logger.new(out, level: Logger::INFO, template: "{{message}}")
       logger.close
       expect(logger.device).to receive(:reopen).and_call_original
       logger.reopen
@@ -284,7 +284,7 @@ RSpec.describe Lumberjack::Logger do
 
   describe "logging methods" do
     let(:out) { StringIO.new }
-    let(:device) { Lumberjack::Device::Writer.new(out, template: "[:time :severity :progname(:pid)] :message :attributes") }
+    let(:device) { Lumberjack::Device::Writer.new(out, template: "[{{time}} {{severity}} {{progname}}({{pid}})] {{message}} {{attributes}}") }
     let(:logger) { Lumberjack::Logger.new(device, level: Logger::INFO, progname: "app") }
     let(:n) { Lumberjack::LINE_SEPARATOR }
 
@@ -458,14 +458,14 @@ RSpec.describe Lumberjack::Logger do
 
     describe "message" do
       it "should apply the default formatter to the message" do
-        logger = Lumberjack::Logger.new(out, template: ":message")
+        logger = Lumberjack::Logger.new(out, template: "{{message}}")
         logger.formatter.add(String) { |msg| msg.upcase }
         logger.info("test")
         expect(out.string.chomp).to eq "TEST"
       end
 
       it "should apply the message formatter instead of the default formatter if it applies" do
-        logger = Lumberjack::Logger.new(out, template: ":message")
+        logger = Lumberjack::Logger.new(out, template: "{{message}}")
         logger.formatter.add(String) { |msg| msg.upcase }
         logger.message_formatter.add(String) { |msg| msg.reverse }
         logger.info("test")
@@ -473,7 +473,7 @@ RSpec.describe Lumberjack::Logger do
       end
 
       it "should copy attributes from the message if the formatter returns a Lumberjack::MessageAttributes" do
-        logger = Lumberjack::Logger.new(out, template: ":message :attributes")
+        logger = Lumberjack::Logger.new(out, template: "{{message}} {{attributes}}")
         logger.formatter.add(String) { |msg| Lumberjack::MessageAttributes.new(msg.upcase, tag: msg.downcase) }
         logger.info("Test")
         expect(out.string.chomp).to eq "TEST [tag:test]"
@@ -487,7 +487,7 @@ RSpec.describe Lumberjack::Logger do
         end
       end
 
-      let(:device) { Lumberjack::Device::Writer.new(out, template: ":message - :count - :attributes") }
+      let(:device) { Lumberjack::Device::Writer.new(out, template: "{{message}} - {{count}} - {{attributes}}") }
 
       it "should be able to add global attributes to the logger" do
         logger.tag_globally(count: 1, foo: "bar")
@@ -506,7 +506,7 @@ RSpec.describe Lumberjack::Logger do
         end
       end
 
-      let(:device) { Lumberjack::Device::Writer.new(out, template: ":message - :count - :attributes") }
+      let(:device) { Lumberjack::Device::Writer.new(out, template: "{{message}} - {{count}} - {{attributes}}") }
 
       it "should remove context attributes in a context block and global attributes outside of one" do
         logger.tag!(foo: "bar", wip: "wap")

--- a/spec/lumberjack/severity_spec.rb
+++ b/spec/lumberjack/severity_spec.rb
@@ -14,17 +14,6 @@ RSpec.describe Lumberjack::Severity do
       expect(Lumberjack::Severity.level_to_label(Logger::UNKNOWN)).to eq("ANY")
       expect(Lumberjack::Severity.level_to_label(100)).to eq("ANY")
     end
-
-    it "converts a level to a padded label" do
-      expect(Lumberjack::Severity.level_to_label(Logger::DEBUG, true)).to eq("DEBUG")
-      expect(Lumberjack::Severity.level_to_label(Logger::INFO, true)).to eq("INFO ")
-      expect(Lumberjack::Severity.level_to_label(Logger::WARN, true)).to eq("WARN ")
-      expect(Lumberjack::Severity.level_to_label(Logger::ERROR, true)).to eq("ERROR")
-      expect(Lumberjack::Severity.level_to_label(Logger::FATAL, true)).to eq("FATAL")
-      expect(Lumberjack::Severity.level_to_label(Lumberjack::Logger::TRACE, true)).to eq("TRACE")
-      expect(Lumberjack::Severity.level_to_label(Logger::UNKNOWN, true)).to eq("ANY  ")
-      expect(Lumberjack::Severity.level_to_label(100, true)).to eq("ANY  ")
-    end
   end
 
   describe "#label_to_level" do
@@ -58,6 +47,21 @@ RSpec.describe Lumberjack::Severity do
 
     it "coerces trace labels to TRACE" do
       expect(Lumberjack::Severity.coerce("TRACE")).to eq(Lumberjack::Logger::TRACE)
+    end
+  end
+
+  describe "#severity" do
+    it "returns the severity data for a given level" do
+      expect(Lumberjack::Severity.data(Logger::DEBUG)).to be_a(Lumberjack::Severity::Data)
+      expect(Lumberjack::Severity.data(Logger::INFO).label).to eq("INFO")
+      expect(Lumberjack::Severity.data(:error).emoji).to eq("❌")
+      expect(Lumberjack::Severity.data("WARN").padded_label).to eq("WARN ")
+      expect(Lumberjack::Severity.data("ERROR").padded_label).to eq("ERROR")
+      expect(Lumberjack::Severity.data(Logger::FATAL).char).to eq("F")
+      expect(Lumberjack::Severity.data(Lumberjack::Logger::TRACE).label).to eq("TRACE")
+      expect(Lumberjack::Severity.data(Logger::UNKNOWN).emoji).to eq("❓")
+      expect(Lumberjack::Severity.data(Logger::UNKNOWN).label).to eq("ANY")
+      expect(Lumberjack::Severity.data(100)).to eq(Lumberjack::Severity.data(Logger::UNKNOWN))
     end
   end
 end

--- a/spec/lumberjack/template_spec.rb
+++ b/spec/lumberjack/template_spec.rb
@@ -8,85 +8,107 @@ RSpec.describe Lumberjack::Template do
   let(:entry) { Lumberjack::LogEntry.new(time, Logger::INFO, "line 1#{Lumberjack::LINE_SEPARATOR}line 2#{Lumberjack::LINE_SEPARATOR}line 3", "app", 12345, "unit_of_work_id" => "ABCD", "foo" => "bar") }
 
   describe "format" do
+    it "has a default format" do
+      template = Lumberjack::Template.new
+      expect(template.call(entry)).to eq("[2011-01-15T14:23:45.123 INFO  app(12345)] line 1 [unit_of_work_id:ABCD] [foo:bar]#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
+    end
+
     it "should format a log entry with a template string" do
-      template = Lumberjack::Template.new(":message - :severity, :time, :progname@:pid (:unit_of_work_id) :attributes")
+      template = Lumberjack::Template.new("{{message}} - {{severity}}, {{time}}, {{progname}}@{{pid}} ({{unit_of_work_id}}) {{attributes}}")
       expect(template.call(entry)).to eq("line 1 - INFO, 2011-01-15T14:23:45.123, app@12345 (ABCD) [foo:bar]#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should be able to specify a template for additional lines in a message" do
-      template = Lumberjack::Template.new(":message (:time)", additional_lines: " // :message")
+      template = Lumberjack::Template.new("{{message}} ({{time}})", additional_lines: " // {{message}}")
       expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123) // line 2 // line 3#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "does not blow up if there is a % in the template" do
-      template = Lumberjack::Template.new("%s :message")
+      template = Lumberjack::Template.new("%s {{message}}")
       expect(template.call(entry)).to eq("%s line 1#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "can pad the severity labels" do
-      template = Lumberjack::Template.new(":severity-:message", pad_severity: true)
+      template = Lumberjack::Template.new("{{severity(padded)}}-{{message}}")
       expect(template.call(entry)).to start_with("INFO -line 1")
+    end
+
+    it "can use a single character for the severity" do
+      template = Lumberjack::Template.new("{{severity(char)}}-{{message}}")
+      expect(template.call(entry)).to start_with("I-line 1")
+    end
+
+    it "can use an emoji for the severity" do
+      template = Lumberjack::Template.new("{{severity(emoji)}}-{{message}}")
+      expect(template.call(entry)).to start_with("🔵-line 1")
+    end
+
+    it "can use the level for the severity" do
+      template = Lumberjack::Template.new("{{severity(level)}}-{{message}}")
+      expect(template.call(entry)).to start_with("1-line 1")
     end
   end
 
   describe "timestamp format" do
     it "should be able to specify the time format for log entries as microseconds" do
-      template = Lumberjack::Template.new(":message (:time)", time_format: :microseconds)
+      template = Lumberjack::Template.new("{{message}} ({{time}})", time_format: :microseconds)
       expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123000)#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should be able to specify the time format for log entries as milliseconds" do
-      template = Lumberjack::Template.new(":message (:time)", time_format: :milliseconds)
+      template = Lumberjack::Template.new("{{message}} ({{time}})", time_format: :milliseconds)
       expect(template.call(entry)).to eq("line 1 (2011-01-15T14:23:45.123)#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should be able to specify the time format for log entries with a custom format" do
-      template = Lumberjack::Template.new(":message (:time)", time_format: "%m/%d/%Y, %I:%M:%S %p")
+      template = Lumberjack::Template.new("{{message}} ({{time}})", time_format: "%m/%d/%Y, %I:%M:%S %p")
       expect(template.call(entry)).to eq("line 1 (01/15/2011, 02:23:45 PM)#{Lumberjack::LINE_SEPARATOR}> line 2#{Lumberjack::LINE_SEPARATOR}> line 3#{Lumberjack::LINE_SEPARATOR}")
     end
   end
 
   describe "attributes" do
-    it "should format named attributes in the template and not in the :attributes placement" do
-      template = Lumberjack::Template.new(":message - :foo - :attributes")
+    it "should format named attributes in the template and not in the {{attributes}} placement" do
+      template = Lumberjack::Template.new("{{message}} - {{foo}} - {{attributes}}")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo" => "bar", "tag" => "a")
       expect(template.call(entry)).to eq("here - bar - [tag:a]#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should put nothing in place of missing named attributes" do
-      template = Lumberjack::Template.new(":message - :foo - :attributes")
+      template = Lumberjack::Template.new("{{message}} - {{foo}} - {{attributes}}")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "tag" => "a")
       expect(template.call(entry)).to eq("here -  - [tag:a]#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should remove line separators in attributes" do
-      template = Lumberjack::Template.new(":message - :foo - :attributes")
+      template = Lumberjack::Template.new("{{message}} - {{foo}} - {{attributes}}")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "tag" => "a#{Lumberjack::LINE_SEPARATOR}b")
       expect(template.call(entry)).to eq("here -  - [tag:a b]#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "should handle attributes with special characters by surrounding with brackets" do
-      template = Lumberjack::Template.new(":message - :{ foo.bar } - :{@baz!} - :{attributes}")
+      template = Lumberjack::Template.new("{{message}} - {{ foo.bar }} - {{@baz!}} - {{ attributes}}")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo.bar" => "test", "@baz!" => 1, "tag" => "a")
       expect(template.call(entry)).to eq("here - test - 1 - [tag:a]#{Lumberjack::LINE_SEPARATOR}")
     end
 
     it "can customize the attribute format" do
-      template = Lumberjack::Template.new(":message - :foo - :attributes", attribute_format: "(%s=%s)")
+      template = Lumberjack::Template.new("{{message}} - {{foo}} - {{attributes}}", attribute_format: "(%s=%s)")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo" => "bar", "tag" => "a")
       expect(template.call(entry)).to eq("here - bar - (tag=a)#{Lumberjack::LINE_SEPARATOR}")
     end
+  end
 
-    it "can use :tags in place of :attributes" do
-      template = Lumberjack::Template.new(":message - :foo - :tags")
-      entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo" => "bar", "tag" => "a")
-      expect(template.call(entry)).to eq("here - bar - [tag:a]#{Lumberjack::LINE_SEPARATOR}")
+  describe "v1 template format" do
+    around do |example|
+      silence_deprecations do
+        example.run
+      end
     end
 
-    it "does not use :tags if :attributes exists" do
-      template = Lumberjack::Template.new(":message - :tags - :attributes")
-      entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "tags" => "a", "foo" => "bar")
-      expect(template.call(entry)).to eq("here - a - [foo:bar]#{Lumberjack::LINE_SEPARATOR}")
+    it "uses :name as placeholders in place of {{name}} and tags instead of attributes" do
+      template = Lumberjack::Template.new(":time :severity :progname, :message: - :foo - :tags")
+      entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo" => "bar", "tag" => "a")
+      expect(template.call(entry)).to eq("2011-01-15T14:23:45.123 INFO app, here: - bar - [tag:a]#{Lumberjack::LINE_SEPARATOR}")
     end
   end
 end


### PR DESCRIPTION
### Added

- Templates can now use variations on the severity label with a format option added to the placeholder: `{{severity(padded)}}`, `{{severity(char)}}`, `{{severity(emoji)}}`, and `{{severity(level)}}`.
- Log entries in templates can now be colorized by severity with the `colorize: true`.

### Deprecated

- Templates now use mustache syntax for placeholders instead of the colon prefix (i.e. `{{message}}` instead of `:message`). The `:tags` placeholder is also now called `{{attributes}}`.
