### PR TITLE
Add method for adding attributes to the parent contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Added `Lumberjack::Logger#tag!` as the preferred method for adding global tags to a logger.
 - Added `Lumberjack::Logger#untag!` to remove global tags from a logger.
 - Added `Lumberjack::Logger#in_context?` as a replacement for `Lumberjack::Logger#in_tag_context?` and `Lumberjack.in_context?` as a replacement for `Lumberjack.context?`.
+- Added `Lumberjack::Logger#tag_parent_contexts` as a means to add attributes to parent context blocks. This allows setting attributes for the scope of the outermost context block.
 - Added IO compatibility methods for logging. Calling `logger.write`, `logger.puts`, `logger.print`, or `logger.printf` will write log entries. The severity of the log entries can be set with `default_severity`.
 - Added `Lumberjack::Device::LoggerWrapper` as a device that forwards entries to another Lumberjack logger.
 - Added `Lumberjack::Device::Test` class for use in testing logging functionality. This device will buffer log entries and has `match?` and `include?` methods that can be used for assertions in tests.

--- a/lib/lumberjack/attributes_helper.rb
+++ b/lib/lumberjack/attributes_helper.rb
@@ -61,6 +61,7 @@ module Lumberjack
       end
 
       return nil if matching_attributes.empty?
+
       matching_attributes
     end
 

--- a/lib/lumberjack/context.rb
+++ b/lib/lumberjack/context.rb
@@ -36,6 +36,11 @@ module Lumberjack
     # @return [Integer, nil] The default severity level, or nil if not set.
     attr_reader :default_severity
 
+    # The parent context from which this context inherited its initial attributes.
+    # @return [Lumberjack::Context, nil] The parent context, or nil if this is a top-level context.
+    # @api private
+    attr_accessor :parent
+
     # Create a new context, optionally inheriting configuration from a parent context.
     #
     # When a parent context is provided, the new context inherits all configuration

--- a/lib/lumberjack/formatter/structured_formatter.rb
+++ b/lib/lumberjack/formatter/structured_formatter.rb
@@ -65,6 +65,7 @@ module Lumberjack
       def with_object_reference(obj, references)
         if obj.is_a?(Enumerable)
           return RecusiveReferenceError.new if references.include?(obj.object_id)
+
           references << obj.object_id
           begin
             yield

--- a/lib/lumberjack/log_entry.rb
+++ b/lib/lumberjack/log_entry.rb
@@ -185,6 +185,7 @@ module Lumberjack
     # @return [Hash] A new hash with empty values removed
     def compact_attributes(attributes, seen = nil)
       return {} if seen&.include?(attributes.object_id)
+
       delete_keys = nil
       compacted_keys = nil
 

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -463,6 +463,7 @@ module Lumberjack
       return false unless object.respond_to?(:write)
       return true if object.respond_to?(:tty?) && object.tty?
       return false if object.respond_to?(:path) && object.path
+
       true
     end
 

--- a/lib/lumberjack/tags.rb
+++ b/lib/lumberjack/tags.rb
@@ -12,6 +12,7 @@ module Lumberjack
       def stringify_keys(hash)
         Utils.deprecated("Lumberjack::Tags.stringify_keys", "Lumberjack::Tags.stringify_keys is no longer supported") do
           return nil if hash.nil?
+
           if hash.keys.all? { |key| key.is_a?(String) }
             hash
           else

--- a/spec/lumberjack/context_logger_spec.rb
+++ b/spec/lumberjack/context_logger_spec.rb
@@ -362,6 +362,24 @@ RSpec.describe Lumberjack::ContextLogger do
     end
   end
 
+  describe "#tag_parent_contexts" do
+    it "adds attributes to the parent contexts in the hierarchy" do
+      logger.tag(foo: "bar") do
+        logger.tag(baz: "qux") do
+          logger.tag_parent_contexts(bip: "bap")
+          expect(logger.attributes).to eq({"foo" => "bar", "baz" => "qux", "bip" => "bap"})
+        end
+        expect(logger.attributes).to eq({"foo" => "bar", "bip" => "bap"})
+      end
+      expect(logger.attributes).to be_empty
+    end
+
+    it "does not attributes to the default context if there is no current context" do
+      logger.tag_parent_contexts(bip: "bap")
+      expect(logger.attributes).to be_empty
+    end
+  end
+
   describe "#tag!" do
     it "adds attributes to the default context" do
       logger_with_default_context.tag!(foo: "bar")

--- a/spec/lumberjack/forked_logger_spec.rb
+++ b/spec/lumberjack/forked_logger_spec.rb
@@ -51,6 +51,31 @@ RSpec.describe Lumberjack::ForkedLogger do
     })
   end
 
+  it "does not bleed attributes to the parent logger contexts" do
+    forked_logger = Lumberjack::ForkedLogger.new(logger)
+    forked_logger.tag_parent_contexts(test: "value")
+    expect(logger.attributes).to be_empty
+
+    forked_logger.tag(foo: "bar") do
+      forked_logger.tag_parent_contexts(test: "value")
+    end
+    expect(logger.attributes).to be_empty
+  end
+
+  it "does not bleed attributes to the default context" do
+    forked_logger = Lumberjack::ForkedLogger.new(logger)
+    forked_logger.tag(test: "value")
+    expect(forked_logger.attributes).to be_empty
+
+    forked_logger.tag_parent_contexts(test: "value")
+    expect(forked_logger.attributes).to be_empty
+
+    forked_logger.tag(foo: "bar") do
+      forked_logger.tag_parent_contexts(test: "value")
+    end
+    expect(forked_logger.attributes).to be_empty
+  end
+
   it "allows setting the progname on the local logger" do
     forked_logger = Lumberjack::ForkedLogger.new(logger)
     forked_logger.progname = "TestProgname"


### PR DESCRIPTION
- Added `Lumberjack::Logger#tag_parent_contexts` as a means to add attributes to parent context blocks. This allows setting attributes for the scope of the outermost context block.
