### PR TITLE
Add deprecation modes for development and testing

### DIFF
--- a/lib/lumberjack/fiber_locals.rb
+++ b/lib/lumberjack/fiber_locals.rb
@@ -8,6 +8,12 @@ module Lumberjack
     # @api private
     class Data
       attr_accessor :context, :logging, :cleared
+
+      def initialize(copy = nil)
+        @context = copy&.context
+        @logging = copy&.logging
+        @cleared = copy&.cleared
+      end
     end
 
     private
@@ -17,7 +23,7 @@ module Lumberjack
 
       fiber_id = Fiber.current.object_id
       current = @fiber_locals[fiber_id]
-      data = current.nil? ? Data.new : current.dup
+      data = Data.new(current)
       begin
         @fiber_locals_mutex.synchronize do
           @fiber_locals[fiber_id] = data

--- a/lib/lumberjack/logger.rb
+++ b/lib/lumberjack/logger.rb
@@ -431,6 +431,8 @@ module Lumberjack
       err << ": #{e.message}" unless e.message.to_s.empty?
       err << " at #{e.backtrace.first}" if e.backtrace
       $stderr.write("#{err}\n#{entry}\n") # rubocop:disable Style/StderrPuts
+
+      raise e if Lumberjack.raise_logger_errors?
     end
 
     # Open a logging device.

--- a/spec/lumberjack/attribute_formatter_spec.rb
+++ b/spec/lumberjack/attribute_formatter_spec.rb
@@ -14,13 +14,7 @@ RSpec.describe Lumberjack::AttributeFormatter do
     end
   end
 
-  describe "#add" do
-    around do |example|
-      silence_deprecations do
-        example.run
-      end
-    end
-
+  describe "#add", deprecation_mode: "silent" do
     it "adds an attribute formatter for a specific attribute" do
       attribute_formatter = Lumberjack::AttributeFormatter.new
       attribute_formatter.add(:foo) { |val| val.to_s.upcase }
@@ -34,13 +28,7 @@ RSpec.describe Lumberjack::AttributeFormatter do
     end
   end
 
-  describe "#remove" do
-    around do |example|
-      silence_deprecations do
-        example.run
-      end
-    end
-
+  describe "#remove", deprecation_mode: "silent" do
     it "removes an attribute formatter for a specific attribute" do
       attribute_formatter = Lumberjack::AttributeFormatter.new
       attribute_formatter.add(:foo) { |val| val.to_s.upcase }

--- a/spec/lumberjack/formatter/tagged_message_spec.rb
+++ b/spec/lumberjack/formatter/tagged_message_spec.rb
@@ -2,11 +2,9 @@
 
 require "spec_helper"
 
-RSpec.describe Lumberjack::Formatter::TaggedMessage do
+RSpec.describe Lumberjack::Formatter::TaggedMessage, deprecation_mode: "silent" do
   it "is a MessageAttributes" do
-    silence_deprecations do
-      obj = Lumberjack::Formatter::TaggedMessage.new("foo", bar: "baz")
-      expect(obj).to be_a(Lumberjack::MessageAttributes)
-    end
+    obj = Lumberjack::Formatter::TaggedMessage.new("foo", bar: "baz")
+    expect(obj).to be_a(Lumberjack::MessageAttributes)
   end
 end

--- a/spec/lumberjack/formatter_spec.rb
+++ b/spec/lumberjack/formatter_spec.rb
@@ -180,11 +180,9 @@ RSpec.describe Lumberjack::Formatter do
     end
   end
 
-  describe "empty" do
+  describe "empty", deprecation_mode: "silent" do
     it "should be able to get an empty formatter" do
-      silence_deprecations do
-        expect(Lumberjack::Formatter.empty.format(:test)).to eq(:test)
-      end
+      expect(Lumberjack::Formatter.empty.format(:test)).to eq(:test)
     end
   end
 

--- a/spec/lumberjack/tags_spec.rb
+++ b/spec/lumberjack/tags_spec.rb
@@ -2,20 +2,16 @@
 
 require "spec_helper"
 
-RSpec.describe Lumberjack::Tags do
+RSpec.describe Lumberjack::Tags, deprecation_mode: "silent" do
   describe "stringify_keys" do
     it "transforms hash keys to strings" do
-      silence_deprecations do
-        hash = {foo: 1, bar: 2}
-        expect(Lumberjack::Tags.stringify_keys(hash)).to eq({"foo" => 1, "bar" => 2})
-      end
+      hash = {foo: 1, bar: 2}
+      expect(Lumberjack::Tags.stringify_keys(hash)).to eq({"foo" => 1, "bar" => 2})
     end
 
     it "returns the hash itself if the keys are already strings" do
-      silence_deprecations do
-        hash = {"foo" => 1, "bar" => 2}
-        expect(Lumberjack::Tags.stringify_keys(hash).object_id).to eq(hash.object_id)
-      end
+      hash = {"foo" => 1, "bar" => 2}
+      expect(Lumberjack::Tags.stringify_keys(hash).object_id).to eq(hash.object_id)
     end
   end
 end

--- a/spec/lumberjack/template_spec.rb
+++ b/spec/lumberjack/template_spec.rb
@@ -98,13 +98,7 @@ RSpec.describe Lumberjack::Template do
     end
   end
 
-  describe "v1 template format" do
-    around do |example|
-      silence_deprecations do
-        example.run
-      end
-    end
-
+  describe "v1 template format", deprecation_mode: "silent" do
     it "uses :name as placeholders in place of {{name}} and tags instead of attributes" do
       template = Lumberjack::Template.new(":time :severity :progname, :message: - :foo - :tags")
       entry = Lumberjack::LogEntry.new(time, Logger::INFO, "here", "app", 12345, "foo" => "bar", "tag" => "a")


### PR DESCRIPTION
Introduce new deprecation modes to control how deprecated methods are handled, including options to raise errors, suppress warnings, or log them. Update tests to utilize the new modes for better control during development and testing.