### PR TITLE
Add template registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This is a major update with several breaking changes. See the [upgrade guide](UP
 - Added `Lumberjack::Formatter::Tags` for formatting attributes as "tags" in the logs. Arrays of values will be formatted as "[val1] [val2]" and hashes will be formatted as "[key1=value1] [key2=value2]".
 - Added `Lumberjack::FormatterRegistry` as a means of associating formatters with a symbol. Symbols can be used when adding class and attribute formatters. This extends the behavior previously limited to the built in formatters so that users can define their own formatters and register them for use.
 - Added `Lumberjack::DeviceRegistry` as a means for associating devices with a symbol. Symbols can then be passed to the constructor when creating a logger and the logger will take care of instantiating the device.
+- Added `Lumberjack::TemplateRegistry` as a means for associating templates with a symbol. Symbols can then be passed to the logger constructor in lieu of the template definition.
 - Added `Lumberjack::Logger#clear_attributes` to remove all attributes from the logger.
 - Added `Lumberjack::MessageAttributes` to replace `Lumberjack::Formatter::TaggedMessage`.
 - Added `Lumberjack::RemapAttribute` to facilitate attribute remapping in attribute formatters.

--- a/README.md
+++ b/README.md
@@ -665,9 +665,19 @@ logger.info("Test message", user_id: 123, status: "active")
 # Output: 2025-09-03 14:30:15  INFO Test message [user_id=123] [status=active]
 ```
 
-##### Test Template
+##### Built-in Templates
 
-You can use the value `:test` to use a template optimized for test environment logs. This template is designed to be easy to read and exclude attributes that are usually not useful in tests like the time and pid.
+You can use symbols to refer to built-in templates:
+
+- `:default` - The default log template. This is the same as not specifying a template.
+- `:stdlib` - A template that mimics the default format of the standard library Logger.
+- `:local` - A simple, human readable template intended for local development and test environments. This template removes the time and pid from the log line since they are generally not needed in these environments. You can also exclude attributes by setting the `exclude_attributes` option to the list of attributes names to exclude. For example, you may want to add a `host` attribute for your production logs, but this just creates clutter in development logs since it is always the same value.
+- `:development` - This is an alias for the `:local` template.
+- `:test` - This is an alias for the `:local` template.
+
+```ruby
+logger = Lumberjack::Logger.new(STDOUT, template: :local, exclude_attributes: ["host", "env", "version"])
+```
 
 ### Testing Utilities
 

--- a/lib/lumberjack.rb
+++ b/lib/lumberjack.rb
@@ -34,6 +34,10 @@ module Lumberjack
 
   LINE_SEPARATOR = ((RbConfig::CONFIG["host_os"] =~ /mswin/i) ? "\r\n" : "\n")
 
+  require_relative "lumberjack/device_registry"
+  require_relative "lumberjack/template_registry"
+  require_relative "lumberjack/formatter_registry"
+
   require_relative "lumberjack/attribute_formatter"
   require_relative "lumberjack/attributes_helper"
   require_relative "lumberjack/context"
@@ -42,19 +46,17 @@ module Lumberjack
   require_relative "lumberjack/io_compatibility"
   require_relative "lumberjack/log_entry"
   require_relative "lumberjack/log_entry_matcher"
-  require_relative "lumberjack/device_registry"
   require_relative "lumberjack/device"
   require_relative "lumberjack/entry_formatter"
-  require_relative "lumberjack/formatter_registry"
   require_relative "lumberjack/formatter"
   require_relative "lumberjack/forked_logger"
   require_relative "lumberjack/logger"
+  require_relative "lumberjack/local_log_template"
   require_relative "lumberjack/message_attributes"
   require_relative "lumberjack/remap_attribute"
   require_relative "lumberjack/rack"
   require_relative "lumberjack/severity"
   require_relative "lumberjack/template"
-  require_relative "lumberjack/test_log_template"
   require_relative "lumberjack/utils"
 
   # Deprecated

--- a/lib/lumberjack/device/writer.rb
+++ b/lib/lumberjack/device/writer.rb
@@ -63,7 +63,7 @@ module Lumberjack
       else
         template = options[:template]
 
-        template = test_log_template(options) if template == :test
+        template = TemplateRegistry.template(template, options) if template.is_a?(Symbol)
 
         @template = if template.respond_to?(:call)
           template

--- a/lib/lumberjack/local_log_template.rb
+++ b/lib/lumberjack/local_log_template.rb
@@ -1,27 +1,34 @@
 # frozen_string_literal: true
 
 module Lumberjack
-  # This is a log template designed for test environments. It provides a simple,
+  # This is a log template designed for local environments. It provides a simple,
   # human-readable format that includes key information about log entries while
   # omitting extraneous details. The template can be configured to include or
   # exclude certain components such as the times, process ID, program name,
   # and attributes.
   #
+  # It is registered with the TemplateRegistry as :local, :test, and :development.
+  #
   # @see Template
-  class TestLogTemplate
-    # Create a new TestLogTemplate instance.
+  class LocalLogTemplate
+    TemplateRegistry.add(:local, self)
+    TemplateRegistry.add(:test, self)
+    TemplateRegistry.add(:development, self)
+
+    # Create a new LocalLogTemplate instance.
     #
-    # @param exclude_attributes [Boolean, Array<String>, nil] If true, all attributes are excluded.
+    # @param options [Hash] Options for configuring the template.
+    # @option options [Boolean, Array<String>, nil] :exclude_attributes If true, all attributes are excluded.
     #   If an array of strings is provided, those attributes (and their sub-attributes) are excluded.
     #   Defaults to nil (include all attributes).
-    # @param exclude_progname [Boolean] If true, the progname is excluded. Defaults to false.
-    # @param exclude_pid [Boolean] If true, the process ID is excluded. Defaults to true.
-    # @param exclude_time [Boolean] If true, the time is excluded. Defaults to true.
-    def initialize(exclude_attributes: nil, exclude_progname: false, exclude_pid: true, exclude_time: true)
-      self.exclude_progname = exclude_progname
-      self.exclude_pid = exclude_pid
-      self.exclude_time = exclude_time
-      self.exclude_attributes = exclude_attributes
+    # @option options [Boolean] :exclude_progname If true, the progname is excluded. Defaults to false.
+    # @option options [Boolean] :exclude_pid If true, the process ID is excluded. Defaults to true.
+    # @option options [Boolean] :exclude_time If true, the time is excluded. Defaults to true.
+    def initialize(options = {})
+      self.exclude_progname = options.fetch(:exclude_progname, false)
+      self.exclude_pid = options.fetch(:exclude_pid, true)
+      self.exclude_time = options.fetch(:exclude_time, true)
+      self.exclude_attributes = options.fetch(:exclude_attributes, nil)
     end
 
     # Format a log entry according to the template.

--- a/lib/lumberjack/template.rb
+++ b/lib/lumberjack/template.rb
@@ -42,8 +42,12 @@ module Lumberjack
   #   template = Lumberjack::Template.new("[{{time}} {{severity}}] (usr:{{user_id}} {{message}} -- {{attributes}})")
   class Template
     DEFAULT_FIRST_LINE_TEMPLATE = "[{{time}} {{severity(padded)}} {{progname}}({{pid}})] {{message}} {{attributes}}"
+    STDLIB_FIRST_LINE_TEMPLATE = "{{severity(char)}}, [{{time}} {{pid}}] {{severity(padded)}} -- {{progname}}: {{message}} {{attributes}}"
     DEFAULT_ADDITIONAL_LINES_TEMPLATE = "#{Lumberjack::LINE_SEPARATOR}> {{message}}"
     DEFAULT_ATTRIBUTE_FORMAT = "[%s:%s]"
+
+    TemplateRegistry.add(:default, DEFAULT_FIRST_LINE_TEMPLATE)
+    TemplateRegistry.add(:stdlib, STDLIB_FIRST_LINE_TEMPLATE)
 
     # A wrapper template that delegates formatting to a standard Ruby Logger formatter.
     # This provides compatibility with existing Logger::Formatter implementations while

--- a/lib/lumberjack/template_registry.rb
+++ b/lib/lumberjack/template_registry.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Lumberjack
+  class TemplateRegistry
+    @templates = {}
+
+    class << self
+      # Register a log template class with a symbol.
+      #
+      # @param name [Symbol] The name of the template.
+      # @param template [String, Class, #call] The log template to register.
+      def add(name, template)
+        unless template.is_a?(String) || template.is_a?(Class) || template.respond_to?(:call)
+          raise ArgumentError.new("template must be a String, Class, or respond to :call")
+        end
+
+        @templates[name.to_sym] = template
+      end
+
+      # Remove a template from the registry.        raise ArgumentError.new("template must be a String, Class, or respond to :call")
+      #
+      # @param name [Symbol] The name of the template to remove.
+      # @return [void]
+      def remove(name)
+        @templates.delete(name.to_sym)
+      end
+
+      # Check if a template is registered.
+      #
+      # @param name [Symbol] The name of the template.
+      # @return [Boolean] True if the template is registered, false otherwise.
+      def registered?(name)
+        @templates.include(name.to_sym)
+      end
+
+      # Get a registered log template class by its symbol.
+      #
+      # @param name [Symbol] The symbol of the registered log template class.
+      # @return [Class, nil] The registered log template class, or nil if not found.
+      def template(name, options = {})
+        template = @templates[name.to_sym]
+        if template.is_a?(Class)
+          template.new(options)
+        elsif template.is_a?(String)
+          template_options = options.slice(:additional_lines, :time_format, :attribute_format, :colorize)
+          Template.new(template, **template_options)
+        else
+          template
+        end
+      end
+
+      # List all registered log template symbols.
+      #
+      # @return [Array<Symbol>] An array of all registered log template symbols.
+      def registered_templates
+        @templates.dup
+      end
+    end
+  end
+end

--- a/spec/lumberjack/device/writer_spec.rb
+++ b/spec/lumberjack/device/writer_spec.rb
@@ -96,11 +96,11 @@ RSpec.describe Lumberjack::Device::Writer do
     expect(stream.string).to eq("TEST MESSAGE#{Lumberjack::LINE_SEPARATOR}")
   end
 
-  it "can write to a test template" do
-    device = Lumberjack::Device::Writer.new(stream, template: :test, exclude_pid: false)
+  it "can write to a template registry template" do
+    device = Lumberjack::Device::Writer.new(stream, template: :local, exclude_pid: false)
     device.write(entry)
     device.flush
-    template = Lumberjack::TestLogTemplate.new(exclude_pid: false)
+    template = Lumberjack::LocalLogTemplate.new(exclude_pid: false)
     expect(stream.string).to eq(template.call(entry) + Lumberjack::LINE_SEPARATOR)
   end
 

--- a/spec/lumberjack/local_log_template_spec.rb
+++ b/spec/lumberjack/local_log_template_spec.rb
@@ -2,13 +2,13 @@
 
 require "spec_helper"
 
-RSpec.describe Lumberjack::TestLogTemplate do
+RSpec.describe Lumberjack::LocalLogTemplate do
   let(:entry) do
     Lumberjack::LogEntry.new(Time.now, Logger::INFO, "test message", "myapp", 1234, "foo" => "bar", "baz.bax" => "qux")
   end
 
   it "formats log entries with values pertinent to test environments" do
-    template = Lumberjack::TestLogTemplate.new
+    template = Lumberjack::LocalLogTemplate.new
     formatted = template.call(entry)
     expected = <<~STRING.chomp
       INFO  test message
@@ -20,7 +20,7 @@ RSpec.describe Lumberjack::TestLogTemplate do
   end
 
   it "can add the time" do
-    template = Lumberjack::TestLogTemplate.new(exclude_time: false)
+    template = Lumberjack::LocalLogTemplate.new(exclude_time: false)
     formatted = template.call(entry)
     expected = <<~STRING.chomp
       #{entry.time.strftime("%Y-%m-%d %H:%M:%S.%6N")} INFO  test message
@@ -32,7 +32,7 @@ RSpec.describe Lumberjack::TestLogTemplate do
   end
 
   it "can add the pid" do
-    template = Lumberjack::TestLogTemplate.new(exclude_pid: false)
+    template = Lumberjack::LocalLogTemplate.new(exclude_pid: false)
     formatted = template.call(entry)
     expected = <<~STRING.chomp
       INFO  test message
@@ -45,7 +45,7 @@ RSpec.describe Lumberjack::TestLogTemplate do
   end
 
   it "can exclude the progname" do
-    template = Lumberjack::TestLogTemplate.new(exclude_progname: true)
+    template = Lumberjack::LocalLogTemplate.new(exclude_progname: true)
     formatted = template.call(entry)
     expected = <<~STRING.chomp
       INFO  test message
@@ -56,7 +56,7 @@ RSpec.describe Lumberjack::TestLogTemplate do
   end
 
   it "can exclude all attributes" do
-    template = Lumberjack::TestLogTemplate.new(exclude_attributes: true)
+    template = Lumberjack::LocalLogTemplate.new(exclude_attributes: true)
     formatted = template.call(entry)
     expected = <<~STRING.chomp
       INFO  test message
@@ -66,7 +66,7 @@ RSpec.describe Lumberjack::TestLogTemplate do
   end
 
   it "can exclude specific attributes" do
-    template = Lumberjack::TestLogTemplate.new(exclude_attributes: ["foo"])
+    template = Lumberjack::LocalLogTemplate.new(exclude_attributes: ["foo"])
     formatted = template.call(entry)
     expected = <<~STRING.chomp
       INFO  test message
@@ -77,7 +77,7 @@ RSpec.describe Lumberjack::TestLogTemplate do
   end
 
   it "can exclude specific nested attributes" do
-    template = Lumberjack::TestLogTemplate.new(exclude_attributes: ["baz"])
+    template = Lumberjack::LocalLogTemplate.new(exclude_attributes: ["baz"])
     formatted = template.call(entry)
     expected = <<~STRING.chomp
       INFO  test message

--- a/spec/lumberjack/template_registry_spec.rb
+++ b/spec/lumberjack/template_registry_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lumberjack::TemplateRegistry do
+  it "has :default, :stdlib, :local, :development, and :test registered by default" do
+    expect(Lumberjack::TemplateRegistry.registered_templates).to eq({
+      default: Lumberjack::Template::DEFAULT_FIRST_LINE_TEMPLATE,
+      stdlib: Lumberjack::Template::STDLIB_FIRST_LINE_TEMPLATE,
+      local: Lumberjack::LocalLogTemplate,
+      development: Lumberjack::LocalLogTemplate,
+      test: Lumberjack::LocalLogTemplate
+    })
+  end
+
+  it "can add new templates to the registry" do
+    template = lambda { |entry| "foobar" }
+    Lumberjack::TemplateRegistry.add(:foobar, template)
+    expect(Lumberjack::TemplateRegistry.template(:foobar)).to eq template
+    expect(Lumberjack::TemplateRegistry.template(:other)).to be_nil
+  ensure
+    Lumberjack::TemplateRegistry.remove(:foobar)
+  end
+
+  it "can instantiate a template class by name and options" do
+    template = Lumberjack::TemplateRegistry.template(:test, exclude_pid: false)
+    expect(template).to be_a(Lumberjack::LocalLogTemplate)
+    expect(template.exclude_pid?).to be false
+  end
+
+  it "can instantiate a template string by name and options" do
+    template = Lumberjack::TemplateRegistry.template(:stdlib)
+    expect(template).to be_a(Lumberjack::Template)
+    entry = Lumberjack::LogEntry.new(Time.now, Logger::INFO, "test message", "myapp", 1234, "foo" => "bar", "baz.bax" => "qux")
+    formatted = template.call(entry)
+    expected = "I, [#{entry.time.strftime("%Y-%m-%dT%H:%M:%S.%3N")} 1234] INFO  -- myapp: test message [foo:bar] [baz.bax:qux]\n"
+    expect(formatted).to eq(expected)
+  end
+end


### PR DESCRIPTION
- Added `Lumberjack::TemplateRegistry` as a means for associating templates with a symbol. Symbols can then be passed to the logger constructor in lieu of the template definition.
