### PR TITLE
Better support for hash_including matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contexts no longer share array attribute values with their parent context, so appending to an inherited array attribute no longer mutates the parent context.
 - `Lumberjack.context` called without a block now returns the current context as documented instead of raising an `ArgumentError`.
 - Renamed misspelled `Lumberjack::Formatter::StructuredFormatter::RecusiveReferenceError` to `RecursiveReferenceError`. The old constant is kept as an alias for backward compatibility.
+- `Lumberjack::LogEntryMatcher` no longer ignores an `attributes` filter that is not a hash. Passing a matcher like RSpec's `hash_including` as the entire filter silently matched every entry; it is now applied to the entry's attributes hash with `===`.
+- `Lumberjack::LogEntryMatcher` now exposes log entry attributes to matchers with indifferent key access, so matchers that do their own key lookups (i.e. RSpec's `hash_including`) can use either string or symbol attribute names.
 
 ## 2.0.5
 

--- a/lib/lumberjack/log_entry_matcher.rb
+++ b/lib/lumberjack/log_entry_matcher.rb
@@ -14,6 +14,7 @@ module Lumberjack
   #
   # @see Lumberjack::Device::Test
   class LogEntryMatcher
+    require_relative "log_entry_matcher/indifferent_hash"
     require_relative "log_entry_matcher/score"
 
     # Create a new log entry matcher with optional filtering criteria. All
@@ -27,14 +28,18 @@ module Lumberjack
     #   Accepts numeric levels or symbolic names (:debug, :info, etc.)
     # @param progname [Object, nil] Pattern to match against program names.
     #   Supports strings, regular expressions, or any object responding to ===
-    # @param attributes [Hash, nil] Hash of attribute patterns to match against
-    #   log entry attributes. Supports nested attribute matching and dot notation
+    # @param attributes [Hash, Object, nil] Hash of attribute patterns to match against
+    #   log entry attributes. Supports nested attribute matching and dot notation.
+    #   Any other object is matched against the entire attributes hash with ===
+    #   so matchers like RSpec's hash_including can be used.
     def initialize(message: nil, severity: nil, progname: nil, attributes: nil)
       message = message.strip if message.is_a?(String)
       @message_filter = message
       @severity_filter = Severity.coerce(severity) if severity
       @progname_filter = progname
-      @attributes_filter = Utils.expand_attributes(attributes) if attributes
+      if attributes
+        @attributes_filter = attributes.is_a?(Hash) ? Utils.expand_attributes(attributes) : attributes
+      end
     end
 
     # Test whether a log entry matches all specified criteria. The entry must
@@ -49,7 +54,7 @@ module Lumberjack
       return false unless match_filter?(entry.progname, @progname_filter)
 
       if @attributes_filter
-        attributes = Utils.expand_attributes(entry.attributes)
+        attributes = IndifferentHash.wrap(Utils.expand_attributes(entry.attributes))
         return false unless match_attributes?(attributes, @attributes_filter)
       end
 
@@ -98,11 +103,13 @@ module Lumberjack
     # with support for partial matching and empty value detection.
     #
     # @param attributes [Hash] The expanded attributes hash from the log entry
-    # @param filter [Hash] The filter patterns to match against attributes
+    # @param filter [Hash, Object] The filter patterns to match against attributes.
+    #   Non-hash filters are matched against the attributes hash itself with ===.
     # @return [Boolean] True if all filter patterns match their corresponding attributes
     def match_attributes?(attributes, filter)
       return true unless filter
       return false unless attributes
+      return match_filter?(attributes, filter) unless filter.is_a?(Hash)
 
       filter.all? do |name, value_filter|
         name = name.to_s

--- a/lib/lumberjack/log_entry_matcher/indifferent_hash.rb
+++ b/lib/lumberjack/log_entry_matcher/indifferent_hash.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# A minimal hash implementation that allows values to be looked up with either
+# string or symbol keys.
+#
+# The keys stored in the hash are left exactly as they are; only lookups are
+# indifferent. Log entry attributes are matched with string keys, but matchers
+# that do their own key lookups on the attributes hash (i.e. RSpec's
+# `hash_including`) have no way of knowing that. Wrapping the attributes in this
+# class lets those matchers use either form.
+#
+# @api private
+class Lumberjack::LogEntryMatcher::IndifferentHash < Hash
+  class << self
+    # Recursively wrap a value so that any hashes in it, including hashes nested
+    # inside arrays, allow indifferent key lookups. Values that are not hashes or
+    # arrays are returned as is.
+    #
+    # @param value [Object] The value to wrap.
+    # @return [Object] The wrapped value.
+    def wrap(value)
+      case value
+      when self
+        value
+      when Hash
+        value.each_with_object(new) { |(key, val), hash| hash[key] = wrap(val) }
+      when Array
+        value.collect { |val| wrap(val) }
+      else
+        value
+      end
+    end
+  end
+
+  # Capture the unaliased implementation so the overrides below can check for a
+  # key without recursing back into themselves.
+  alias_method :stored_key?, :key?
+  private :stored_key?
+
+  def [](key)
+    super(resolve_key(key))
+  end
+
+  def fetch(key, *args, &block)
+    super(resolve_key(key), *args, &block)
+  end
+
+  def dig(key, *rest)
+    super(resolve_key(key), *rest)
+  end
+
+  def values_at(*keys)
+    super(*keys.collect { |key| resolve_key(key) })
+  end
+
+  def key?(key)
+    stored_key?(resolve_key(key))
+  end
+
+  alias_method :has_key?, :key?
+  alias_method :include?, :key?
+  alias_method :member?, :key?
+
+  private
+
+  # Return the key as it is stored in the hash. If the key is not present in
+  # either its string or symbol form, then the key itself is returned so that
+  # normal missing key semantics apply.
+  #
+  # @param key [Object] The key being looked up.
+  # @return [Object] The key to use for the lookup.
+  def resolve_key(key)
+    return key if stored_key?(key)
+
+    alternate = if key.is_a?(String)
+      key.to_sym
+    elsif key.is_a?(Symbol)
+      key.to_s
+    end
+
+    (alternate && stored_key?(alternate)) ? alternate : key
+  end
+end

--- a/lib/lumberjack/log_entry_matcher/score.rb
+++ b/lib/lumberjack/log_entry_matcher/score.rb
@@ -47,9 +47,15 @@ class Lumberjack::LogEntryMatcher::Score
       end
 
       # Check attributes match
-      if attributes.is_a?(Hash) && !attributes.empty?
-        attributes_score = calculate_attributes_score(entry.attributes, attributes)
-        scores << attributes_score
+      if attributes.is_a?(Hash)
+        unless attributes.empty?
+          scores << calculate_attributes_score(entry.attributes, attributes)
+          weights << 0.3
+        end
+      elsif attributes
+        # Matchers like RSpec's hash_including are applied to the attributes hash as a whole.
+        entry_attributes = Lumberjack::LogEntryMatcher::IndifferentHash.wrap(Lumberjack::Utils.expand_attributes(entry.attributes))
+        scores << calculate_field_score(entry_attributes, attributes)
         weights << 0.3
       end
 
@@ -132,7 +138,9 @@ class Lumberjack::LogEntryMatcher::Score
       return 0.0 unless entry_attributes && attributes_filter.is_a?(Hash)
 
       attributes_filter = deep_stringify_keys(Lumberjack::Utils.expand_attributes(attributes_filter))
-      attributes = deep_stringify_keys(Lumberjack::Utils.expand_attributes(entry_attributes))
+      attributes = Lumberjack::LogEntryMatcher::IndifferentHash.wrap(
+        deep_stringify_keys(Lumberjack::Utils.expand_attributes(entry_attributes))
+      )
 
       total_attribute_filters = count_attribute_filters(attributes_filter)
       return 0.0 if total_attribute_filters == 0

--- a/spec/lumberjack/log_entry_matcher/indifferent_hash_spec.rb
+++ b/spec/lumberjack/log_entry_matcher/indifferent_hash_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe Lumberjack::LogEntryMatcher::IndifferentHash do
+  let(:hash) { Lumberjack::LogEntryMatcher::IndifferentHash.wrap({"foo" => "bar"}.merge(baz: "boo")) }
+
+  it "looks up values with either string or symbol keys" do
+    expect(hash["foo"]).to eq "bar"
+    expect(hash[:foo]).to eq "bar"
+    expect(hash["baz"]).to eq "boo"
+    expect(hash[:baz]).to eq "boo"
+    expect(hash["nope"]).to be_nil
+    expect(hash[:nope]).to be_nil
+  end
+
+  it "keeps the original keys" do
+    expect(hash.keys).to eq ["foo", :baz]
+    expect(hash).to eq({"foo" => "bar"}.merge(baz: "boo"))
+  end
+
+  it "checks for keys in either form" do
+    expect(hash.key?("foo")).to be true
+    expect(hash.key?(:foo)).to be true
+    expect(hash.include?(:foo)).to be true
+    expect(hash.has_key?(:foo)).to be true
+    expect(hash.member?(:foo)).to be true
+    expect(hash.key?("nope")).to be false
+    expect(hash.key?(:nope)).to be false
+    expect(hash.key?(1)).to be false
+  end
+
+  it "fetches values with either form" do
+    expect(hash.fetch(:foo)).to eq "bar"
+    expect(hash.fetch("baz")).to eq "boo"
+    expect(hash.fetch(:nope, "default")).to eq "default"
+    expect(hash.fetch(:nope) { "block" }).to eq "block"
+    expect { hash.fetch(:nope) }.to raise_error(KeyError)
+  end
+
+  it "returns values at multiple keys with either form" do
+    expect(hash.values_at(:foo, "baz")).to eq ["bar", "boo"]
+  end
+
+  it "wraps nested hashes and hashes inside arrays" do
+    nested = Lumberjack::LogEntryMatcher::IndifferentHash.wrap({foo: {"bar" => {baz: "boo"}}, list: [{"a" => 1}]})
+    expect(nested.dig("foo", :bar, "baz")).to eq "boo"
+    expect(nested["foo"]["bar"][:baz]).to eq "boo"
+    expect(nested[:list].first[:a]).to eq 1
+  end
+
+  it "returns non hash values as is" do
+    expect(Lumberjack::LogEntryMatcher::IndifferentHash.wrap("foo")).to eq "foo"
+    expect(Lumberjack::LogEntryMatcher::IndifferentHash.wrap(nil)).to be_nil
+  end
+
+  it "does not rewrap a hash that is already indifferent" do
+    expect(Lumberjack::LogEntryMatcher::IndifferentHash.wrap(hash)).to be hash
+  end
+end

--- a/spec/lumberjack/log_entry_matcher_spec.rb
+++ b/spec/lumberjack/log_entry_matcher_spec.rb
@@ -180,6 +180,34 @@ RSpec.describe Lumberjack::LogEntryMatcher do
         matcher = Lumberjack::LogEntryMatcher.new(attributes: {key: "value"})
         expect(matcher.match?(entry)).to be false
       end
+
+      it "matches a hash matcher against a nested attribute" do
+        attributes["foo.bar"] = "baz"
+        attributes["foo.bip"] = "bop"
+        expect(Lumberjack::LogEntryMatcher.new(attributes: {foo: hash_including("bar" => "baz")}).match?(entry)).to be true
+        expect(Lumberjack::LogEntryMatcher.new(attributes: {foo: hash_including("bar" => "boo")}).match?(entry)).to be false
+        expect(Lumberjack::LogEntryMatcher.new(attributes: {foo: hash_including("nope" => "baz")}).match?(entry)).to be false
+        expect(Lumberjack::LogEntryMatcher.new(attributes: {nope: hash_including("bar" => "baz")}).match?(entry)).to be false
+      end
+
+      it "matches a hash matcher against the entire attributes hash" do
+        attributes["foo.bar"] = "baz"
+        attributes["key"] = "value"
+        expect(Lumberjack::LogEntryMatcher.new(attributes: hash_including("foo" => {"bar" => "baz"})).match?(entry)).to be true
+        expect(Lumberjack::LogEntryMatcher.new(attributes: hash_including("foo" => {"bar" => "boo"})).match?(entry)).to be false
+        expect(Lumberjack::LogEntryMatcher.new(attributes: hash_including("nope" => "baz")).match?(entry)).to be false
+        expect(Lumberjack::LogEntryMatcher.new(attributes: hash_including("key" => "value")).match?(entry)).to be true
+      end
+
+      it "allows hash matchers to use either string or symbol keys" do
+        attributes["foo.bar"] = "baz"
+        expect(Lumberjack::LogEntryMatcher.new(attributes: hash_including(foo: {bar: "baz"})).match?(entry)).to be true
+        expect(Lumberjack::LogEntryMatcher.new(attributes: hash_including(foo: {bar: "boo"})).match?(entry)).to be false
+        expect(Lumberjack::LogEntryMatcher.new(attributes: hash_including(nope: "baz")).match?(entry)).to be false
+        expect(Lumberjack::LogEntryMatcher.new(attributes: {foo: hash_including(bar: "baz")}).match?(entry)).to be true
+        expect(Lumberjack::LogEntryMatcher.new(attributes: {foo: hash_including(bar: "boo")}).match?(entry)).to be false
+        expect(Lumberjack::LogEntryMatcher.new(attributes: {foo: hash_including(nope: "baz")}).match?(entry)).to be false
+      end
     end
 
     describe "multiple filters" do


### PR DESCRIPTION
- `Lumberjack::LogEntryMatcher` no longer ignores an `attributes` filter that is not a hash. Passing a matcher like RSpec's `hash_including` as the entire filter silently matched every entry; it is now applied to the entry's attributes hash with `===`.
- `Lumberjack::LogEntryMatcher` now exposes log entry attributes to matchers with indifferent key access, so matchers that do their own key lookups (i.e. RSpec's `hash_including`) can use either string or symbol attribute names.
